### PR TITLE
Improve message format

### DIFF
--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -52,15 +52,15 @@ namespace MartinCostello.Logging.XUnit
         /// </summary>
         /// <param name="name">The name for messages produced by the logger.</param>
         /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to use.</param>
-        /// <param name="filter">The category filter to apply to logs.</param>
+        /// <param name="options">The <see cref="XUnitLoggerOptions"/> to use.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> or <paramref name="outputHelper"/> is <see langword="null"/>.
         /// </exception>
-        public XUnitLogger(string name, ITestOutputHelper outputHelper, Func<string, LogLevel, bool> filter)
+        public XUnitLogger(string name, ITestOutputHelper outputHelper, XUnitLoggerOptions options)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
-            Filter = filter ?? ((category, logLevel) => true);
+            Filter = options?.Filter ?? ((category, logLevel) => true);
         }
 
         /// <summary>
@@ -79,6 +79,11 @@ namespace MartinCostello.Logging.XUnit
         /// Gets the name of the logger.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets or sets a delegate representing the system clock.
+        /// </summary>
+        internal Func<DateTimeOffset> Clock { get; set; } = () => DateTimeOffset.Now;
 
         /// <inheritdoc />
         public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
@@ -161,11 +166,8 @@ namespace MartinCostello.Logging.XUnit
                 logBuilder.Append(exception.ToString());
             }
 
-            if (logBuilder.Length > 0)
-            {
-                string formatted = logBuilder.ToString();
-                _outputHelper.WriteLine($"[{DateTimeOffset.Now:u}] {logLevelString}{formatted}");
-            }
+            string formatted = logBuilder.ToString();
+            _outputHelper.WriteLine($"[{Clock():u}] {logLevelString}{formatted}");
 
             logBuilder.Clear();
 
@@ -192,16 +194,16 @@ namespace MartinCostello.Logging.XUnit
                     return "crit";
 
                 case LogLevel.Debug:
-                    return "debug";
+                    return "dbug";
 
                 case LogLevel.Error:
-                    return "error";
+                    return "fail";
 
                 case LogLevel.Information:
                     return "info";
 
                 case LogLevel.Trace:
-                    return "trace";
+                    return "trce";
 
                 case LogLevel.Warning:
                     return "warn";

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -45,7 +45,7 @@ namespace MartinCostello.Logging.XUnit
         }
 
         /// <inheritdoc />
-        public virtual ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _outputHelper, _options.Filter);
+        public virtual ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _outputHelper, _options);
 
         /// <inheritdoc />
         public void Dispose()

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -18,13 +18,12 @@ namespace MartinCostello.Logging.XUnit
             // Arrange
             var builder = Mock.Of<ILoggingBuilder>();
             var outputHelper = Mock.Of<ITestOutputHelper>();
-            Action<XUnitLoggerOptions> configure = (p) => { };
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(outputHelper));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(outputHelper, configure));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(outputHelper, Configure));
             Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null as ITestOutputHelper));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null, configure));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null, Configure));
             Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, null as Action<XUnitLoggerOptions>));
         }
 
@@ -33,26 +32,35 @@ namespace MartinCostello.Logging.XUnit
         {
             // Arrange
             ILoggerFactory factory = NullLoggerFactory.Instance;
+            var logLevel = LogLevel.Information;
             var outputHelper = Mock.Of<ITestOutputHelper>();
             var options = new XUnitLoggerOptions();
-            Action<XUnitLoggerOptions> configureAction = (p) => { };
-            Func<XUnitLoggerOptions> configureFunc = () => new XUnitLoggerOptions();
-            Func<string, LogLevel, bool> filter = (c, l) => true;
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper));
             Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, options));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, configureAction));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, configureFunc));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, filter));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, Configure));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, Configure));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, Filter));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory).AddXUnit(outputHelper, logLevel));
             Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null as ITestOutputHelper));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, Configure));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, Configure));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, Filter));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, logLevel));
             Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, options));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, configureAction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null, configureFunc));
             Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(outputHelper, null as XUnitLoggerOptions));
             Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, null as Action<XUnitLoggerOptions>));
             Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, null as Func<XUnitLoggerOptions>));
             Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(outputHelper, null as Func<string, LogLevel, bool>));
         }
+
+        private static void Configure(XUnitLoggerOptions options)
+        {
+        }
+
+        private static XUnitLoggerOptions Configure() => new XUnitLoggerOptions();
+
+        private static bool Filter(string categoryName, LogLevel level) => true;
     }
 }

--- a/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    public static class XUnitLoggerProviderTests
+    {
+        [Fact]
+        public static void XUnitLoggerProvider_Constructor_Validates_Parameters()
+        {
+            // Arrange
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+            var options = new XUnitLoggerOptions();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLoggerProvider(null, options));
+            Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(outputHelper, null));
+        }
+
+        [Fact]
+        public static void XUnitLoggerProvider_Creates_Logger()
+        {
+            // Arrange
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+            var options = new XUnitLoggerOptions();
+
+            string categoryName = "MyLogger";
+
+            using (var target = new XUnitLoggerProvider(outputHelper, options))
+            {
+                // Act
+                ILogger actual = target.CreateLogger(categoryName);
+
+                // Assert
+                actual.ShouldNotBeNull();
+
+                var xunit = actual.ShouldBeOfType<XUnitLogger>();
+                xunit.Name.ShouldBe(categoryName);
+                xunit.Filter.ShouldBeSameAs(options.Filter);
+            }
+        }
+    }
+}

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -1,0 +1,386 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    public static class XUnitLoggerTests
+    {
+        [Fact]
+        public static void XUnitLogger_Validates_Parameters()
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterFalse,
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("name", () => new XUnitLogger(null, outputHelper, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLogger(name, null, options));
+
+            // Arrange
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("value", () => logger.Filter = null);
+        }
+
+        [Fact]
+        public static void XUnitLogger_Constructor_Initializes_Instance()
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            // Act
+            var actual = new XUnitLogger(name, outputHelper, options);
+
+            // Assert
+            actual.Filter.ShouldBeSameAs(options.Filter);
+            actual.Name.ShouldBe(name);
+
+            // Act
+            actual = new XUnitLogger(name, outputHelper, null);
+
+            // Assert
+            actual.Filter.ShouldNotBeNull();
+            actual.Filter(null, LogLevel.None).ShouldBeTrue();
+            actual.Name.ShouldBe(name);
+        }
+
+        [Fact]
+        public static void XUnitLogger_BeginScope_Returns_Value()
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+            var options = new XUnitLoggerOptions();
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            using (IDisposable actual = logger.BeginScope(true))
+            {
+                // Assert
+                actual.ShouldNotBeNull();
+            }
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical, true)]
+        [InlineData(LogLevel.Debug, false)]
+        [InlineData(LogLevel.Error, true)]
+        [InlineData(LogLevel.Information, false)]
+        [InlineData(LogLevel.None, false)]
+        [InlineData(LogLevel.Trace, false)]
+        [InlineData(LogLevel.Warning, true)]
+        public static void XUnitLogger_IsEnabled_Returns_Correct_Result(LogLevel logLevel, bool expected)
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+
+            bool CustomFilter(string categoryName, LogLevel level)
+            {
+                categoryName.ShouldBe(name);
+                level.ShouldBe(logLevel);
+                return level > LogLevel.Information;
+            }
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = CustomFilter,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            bool actual = logger.IsEnabled(logLevel);
+
+            // Assert
+            actual.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Throws_If_Formatter_Is_Null()
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+            var options = new XUnitLoggerOptions();
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("formatter", () => logger.Log(LogLevel.Information, new EventId(2), true, null, null));
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Throws_If_LogLevel_Is_Invalid()
+        {
+            // Arrange
+            string name = "MyName";
+            var outputHelper = Mock.Of<ITestOutputHelper>();
+            var options = new XUnitLoggerOptions();
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act and Assert
+            Assert.Throws<ArgumentOutOfRangeException>("logLevel", () => logger.Log((LogLevel)int.MaxValue, 0, "state", null, Formatter));
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Does_Nothing_If_Not_Enabled()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterFalse,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            logger.Log(LogLevel.Information, new EventId(2), "state", null, Formatter);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Does_Nothing_If_Null_Message_And_No_Exception()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            logger.Log(LogLevel.Information, new EventId(2), "state", null, FormatterNull);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Does_Nothing_If_Empty_Message_And_No_Exception()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            logger.Log(LogLevel.Information, new EventId(2), "state", null, FormatterEmpty);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Only_Exception()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            var exception = new InvalidOperationException("Invalid");
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { "[2018-08-19 16:12:16Z] info: MyName[2]", "System.InvalidOperationException: Invalid" });
+
+            // Act
+            logger.Log(LogLevel.Information, new EventId(2), "state", exception, FormatterNull);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Message_And_Exception()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            var exception = new InvalidOperationException("Invalid");
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { "[2018-08-19 16:12:16Z] warn: MyName[3]", "      Message|False|True", "System.InvalidOperationException: Invalid" });
+
+            // Act
+            logger.Log<string>(LogLevel.Warning, new EventId(3), null, exception, Formatter);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Message_And_No_Exception()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { "[2018-08-19 16:12:16Z] fail: MyName[4]", "      Message|False|False" });
+
+            // Act
+            logger.Log<string>(LogLevel.Error, new EventId(4), null, null, Formatter);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical, "crit")]
+        [InlineData(LogLevel.Debug, "dbug")]
+        [InlineData(LogLevel.Error, "fail")]
+        [InlineData(LogLevel.Information, "info")]
+        [InlineData(LogLevel.Trace, "trce")]
+        [InlineData(LogLevel.Warning, "warn")]
+        public static void XUnitLogger_Log_Logs_Messages(LogLevel logLevel, string shortLevel)
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "Your Name";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { $"[2018-08-19 16:12:16Z] {shortLevel}: Your Name[85]", "      Message|True|False" });
+
+            // Act
+            logger.Log(logLevel, new EventId(85), "Martin", null, Formatter);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Very_Long_Messages()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options);
+
+            // Act
+            logger.Log(LogLevel.Information, 1, "state", null, FormatterLong);
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(It.Is<string>((r) => r.Length > 1024)), Times.Once());
+        }
+
+        private static DateTimeOffset StaticClock() => new DateTimeOffset(2018, 08, 19, 17, 12, 16, TimeSpan.FromHours(1));
+
+        private static bool FilterTrue(string categoryName, LogLevel level) => true;
+
+        private static bool FilterFalse(string categoryName, LogLevel level) => false;
+
+        private static string Formatter<TState>(TState state, Exception exception)
+            where TState : class
+        {
+            return $"Message|{(state == null ? bool.FalseString : bool.TrueString)}|{(exception == null ? bool.FalseString : bool.TrueString)}";
+        }
+
+        private static string FormatterEmpty<TState>(TState state, Exception exception) => string.Empty;
+
+        private static string FormatterLong<TState>(TState state, Exception exception) => new string('a', 2048);
+
+        private static string FormatterNull<TState>(TState state, Exception exception) => null;
+    }
+}


### PR DESCRIPTION
  * Change the logger output to match the default console logger and to be more performant.
  * Change constructor to `XUnitLogger` to accept `XUnitLoggerOptions` for future extensibility without breaking changes to the constructor (or having to add loads of constructor overloads).
  * Change the filters to all being 4 letters in length for consistency.
  * Remove redundant `if` condition check.
  * Improve code coverage (see #1).
