### PR TITLE
Add ITestOutputHelper extensions

### DIFF
--- a/src/Logging.XUnit/ITestOutputHelperExtensions.cs
+++ b/src/Logging.XUnit/ITestOutputHelperExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+
+namespace Xunit.Abstractions
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="ITestOutputHelper"/> interface. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class ITestOutputHelperExtensions
+    {
+        /// <summary>
+        /// Returns an <see cref="ILoggerFactory"/> that logs to the output helper.
+        /// </summary>
+        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to create the logger factory from.</param>
+        /// <returns>
+        /// An <see cref="ILoggerFactory"/> that writes messages to the test output helper.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="outputHelper"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory ToLoggerFactory(this ITestOutputHelper outputHelper)
+        {
+            if (outputHelper == null)
+            {
+                throw new ArgumentNullException(nameof(outputHelper));
+            }
+
+            return new LoggerFactory().AddXUnit(outputHelper);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="ILogger{T}"/> that logs to the output helper.
+        /// </summary>
+        /// <typeparam name="T">The type of the logger to create.</typeparam>
+        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to create the logger from.</param>
+        /// <returns>
+        /// An <see cref="ILogger{T}"/> that writes messages to the test output helper.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="outputHelper"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILogger<T> ToLogger<T>(this ITestOutputHelper outputHelper)
+            => outputHelper.ToLoggerFactory().CreateLogger<T>();
+    }
+}

--- a/tests/Logging.XUnit.Tests/Example.cs
+++ b/tests/Logging.XUnit.Tests/Example.cs
@@ -20,7 +20,7 @@ namespace MartinCostello.Logging.XUnit
         private ITestOutputHelper OutputHelper { get; }
 
         [Fact]
-        public void Calculator_Sums_Two_Integers()
+        public void Calculator_Sums_Two_Different_Integers()
         {
             // Arrange
             var services = new ServiceCollection()
@@ -38,7 +38,20 @@ namespace MartinCostello.Logging.XUnit
             actual.ShouldBe(3);
         }
 
-        public sealed class Calculator
+        [Fact]
+        public void Calculator_Sums_Two_Equal_Integers()
+        {
+            // Arrange
+            var calculator = new Calculator(OutputHelper.ToLogger<Calculator>());
+
+            // Act
+            int actual = calculator.Sum(2, 2);
+
+            // Assert
+            actual.ShouldBe(4);
+        }
+
+        private sealed class Calculator
         {
             private readonly ILogger _logger;
 

--- a/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
+++ b/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Tests for MartinCostello.Logging.XUnit.</Description>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1034;CA1707</NoWarn>
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Logging.XUnit</RootNamespace>
     <Summary>$(Description)</Summary>

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -55,6 +55,16 @@ namespace MartinCostello.Logging.XUnit
             Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(outputHelper, null as Func<string, LogLevel, bool>));
         }
 
+        [Fact]
+        public static void ToLoggerFactory_Validates_Parameters()
+        {
+            // Arrange
+            ITestOutputHelper outputHelper = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("outputHelper", () => outputHelper.ToLoggerFactory());
+        }
+
         private static void ConfigureAction(XUnitLoggerOptions options)
         {
         }


### PR DESCRIPTION
Add extensions to go straight from either `ITestOutputHelper` to `ILoggerFactory` or `ILogger<T>`.
