### PR TITLE
Fix ITestOutputHelperExtensions accessibility

### DIFF
--- a/src/Logging.XUnit/ITestOutputHelperExtensions.cs
+++ b/src/Logging.XUnit/ITestOutputHelperExtensions.cs
@@ -11,7 +11,7 @@ namespace Xunit.Abstractions
     /// A class containing extension methods for the <see cref="ITestOutputHelper"/> interface. This class cannot be inherited.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal static class ITestOutputHelperExtensions
+    public static class ITestOutputHelperExtensions
     {
         /// <summary>
         /// Returns an <see cref="ILoggerFactory"/> that logs to the output helper.


### PR DESCRIPTION
Fix the `ITestOutputHelperExtensions` class added by #4 being declared as `internal` instead of `public`.
