### PR TITLE
Add ITestOutputHelperAccessor

### DIFF
--- a/Logging.XUnit.sln
+++ b/Logging.XUnit.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MartinCostello.Logging.XUni
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MartinCostello.Logging.XUnit", "src\Logging.XUnit\MartinCostello.Logging.XUnit.csproj", "{BB443063-F523-474D-83E3-D5FF5B075950}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "tests\SampleApp\SampleApp.csproj", "{B690F271-3B5D-4975-A607-AED1768595B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,10 @@ Global
 		{BB443063-F523-474D-83E3-D5FF5B075950}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB443063-F523-474D-83E3-D5FF5B075950}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB443063-F523-474D-83E3-D5FF5B075950}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B690F271-3B5D-4975-A607-AED1768595B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B690F271-3B5D-4975-A607-AED1768595B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B690F271-3B5D-4975-A607-AED1768595B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B690F271-3B5D-4975-A607-AED1768595B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +82,7 @@ Global
 		{F37263E7-6656-4A2B-B02E-538B5F9970BD} = {D0426D09-1FF8-4E1F-A9AF-38DDEE5D7CCA}
 		{331BC69B-DFFC-4174-8A97-6335BF6D86CF} = {278BCCB1-39B2-46DB-9395-7F85995A6132}
 		{BB443063-F523-474D-83E3-D5FF5B075950} = {2684B19D-7D49-4099-8BD2-4D281455EB29}
+		{B690F271-3B5D-4975-A607-AED1768595B1} = {278BCCB1-39B2-46DB-9395-7F85995A6132}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3B9E157C-5E92-4357-B233-281B4530EABD}

--- a/src/Logging.XUnit/AmbientTestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit/AmbientTestOutputHelperAccessor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing an implementation of <see cref="ITestOutputHelperAccessor"/> that
+    /// stores the <see cref="ITestOutputHelper"/> as an asynchronous local value. This class cannot be inherited.
+    /// </summary>
+    internal sealed class AmbientTestOutputHelperAccessor : ITestOutputHelperAccessor
+    {
+        /// <summary>
+        /// A backing field for the <see cref="ITestOutputHelper"/> for the current thread.
+        /// </summary>
+        private static readonly AsyncLocal<ITestOutputHelper> _current = new AsyncLocal<ITestOutputHelper>();
+
+#pragma warning disable CA1822
+        /// <summary>
+        /// Gets or sets the current <see cref="ITestOutputHelper"/>.
+        /// </summary>
+        public ITestOutputHelper OutputHelper
+        {
+            get { return _current.Value; }
+            set { _current.Value = value; }
+        }
+#pragma warning restore CA1822
+    }
+}

--- a/src/Logging.XUnit/ITestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit/ITestOutputHelperAccessor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// Defines a property for accessing an <see cref="ITestOutputHelper"/>.
+    /// </summary>
+    public interface ITestOutputHelperAccessor
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ITestOutputHelper"/> to use.
+        /// </summary>
+        ITestOutputHelper OutputHelper { get; set; }
+    }
+}

--- a/src/Logging.XUnit/TestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit/TestOutputHelperAccessor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing the default implementation of <see cref="ITestOutputHelperAccessor"/>. This class cannot be inherited.
+    /// </summary>
+    internal sealed class TestOutputHelperAccessor : ITestOutputHelperAccessor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestOutputHelperAccessor"/> class.
+        /// </summary>
+        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="outputHelper"/> is <see langword="null"/>.
+        /// </exception>
+        internal TestOutputHelperAccessor(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
+        }
+
+        /// <summary>
+        /// Gets or sets the current <see cref="ITestOutputHelper"/>.
+        /// </summary>
+        public ITestOutputHelper OutputHelper { get; set; }
+    }
+}

--- a/src/Logging.XUnit/XUnitLoggerExtensions.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using MartinCostello.Logging.XUnit;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging
@@ -14,6 +15,91 @@ namespace Microsoft.Extensions.Logging
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class XUnitLoggerExtensions
     {
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/>  is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.AddXUnit(new AmbientTestOutputHelperAccessor(), (_) => { });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="accessor"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelperAccessor accessor)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (accessor == null)
+            {
+                throw new ArgumentNullException(nameof(accessor));
+            }
+
+            return builder.AddXUnit(accessor, (_) => { });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
+        /// <param name="configure">A delegate to a method to use to configure the logging options.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/>, <paramref name="accessor"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelperAccessor accessor, Action<XUnitLoggerOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (accessor == null)
+            {
+                throw new ArgumentNullException(nameof(accessor));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var options = new XUnitLoggerOptions();
+
+            configure(options);
+
+            builder.AddProvider(new XUnitLoggerProvider(accessor, options));
+            builder.Services.TryAddSingleton(accessor);
+
+            return builder;
+        }
+
         /// <summary>
         /// Adds an xunit logger to the logging builder.
         /// </summary>

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -13,9 +13,9 @@ namespace MartinCostello.Logging.XUnit
     public class XUnitLoggerProvider : ILoggerProvider
     {
         /// <summary>
-        /// The <see cref="ITestOutputHelper"/> to use. This field is readonly.
+        /// The <see cref="ITestOutputHelperAccessor"/> to use. This field is readonly.
         /// </summary>
-        private readonly ITestOutputHelper _outputHelper;
+        private readonly ITestOutputHelperAccessor _accessor;
 
         /// <summary>
         /// The <see cref="XUnitLoggerOptions"/> to use. This field is readonly.
@@ -31,8 +31,21 @@ namespace MartinCostello.Logging.XUnit
         /// <paramref name="outputHelper"/> or <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
         public XUnitLoggerProvider(ITestOutputHelper outputHelper, XUnitLoggerOptions options)
+            : this(new TestOutputHelperAccessor(outputHelper), options)
         {
-            _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="accessor"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLoggerProvider(ITestOutputHelperAccessor accessor, XUnitLoggerOptions options)
+        {
+            _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
@@ -45,7 +58,7 @@ namespace MartinCostello.Logging.XUnit
         }
 
         /// <inheritdoc />
-        public virtual ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _outputHelper, _options);
+        public virtual ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _accessor, _options);
 
         /// <inheritdoc />
         public void Dispose()

--- a/tests/Logging.XUnit.Tests/Integration/HttpApplicationTests.cs
+++ b/tests/Logging.XUnit.Tests/Integration/HttpApplicationTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    [Collection(HttpServerCollection.Name)]
+    public sealed class HttpApplicationTests : IDisposable
+    {
+        public HttpApplicationTests(HttpServerFixture fixture, ITestOutputHelper outputHelper)
+        {
+            Fixture = fixture;
+            Fixture.SetOutputHelper(outputHelper);
+        }
+
+        private HttpServerFixture Fixture { get; }
+
+        public void Dispose()
+        {
+            Fixture.ClearOutputHelper();
+        }
+
+        [Fact]
+        public async Task Http_Get_Many()
+        {
+            // Arrange
+            using (var httpClient = Fixture.CreateClient())
+            {
+                // Act
+                using (var response = await httpClient.GetAsync("api/values"))
+                {
+                    // Assert
+                    response.IsSuccessStatusCode.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Http_Get_Single()
+        {
+            // Arrange
+            using (var httpClient = Fixture.CreateClient())
+            {
+                // Act
+                using (var response = await httpClient.GetAsync("api/values/a"))
+                {
+                    // Assert
+                    response.IsSuccessStatusCode.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Http_Post()
+        {
+            // Arrange
+            using (var httpClient = Fixture.CreateClient())
+            {
+                // Act
+                using (var response = await httpClient.PostAsJsonAsync("api/values", "d"))
+                {
+                    // Assert
+                    response.IsSuccessStatusCode.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Http_Put()
+        {
+            // Arrange
+            using (var httpClient = Fixture.CreateClient())
+            {
+                // Act
+                using (var response = await httpClient.PutAsJsonAsync("api/values/d", "d"))
+                {
+                    // Assert
+                    response.IsSuccessStatusCode.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Http_Delete()
+        {
+            // Arrange
+            using (var httpClient = Fixture.CreateClient())
+            {
+                // Act
+                using (var response = await httpClient.DeleteAsync("api/values/d"))
+                {
+                    // Assert
+                    response.IsSuccessStatusCode.ShouldBeTrue();
+                }
+            }
+        }
+    }
+}

--- a/tests/Logging.XUnit.Tests/Integration/HttpServerCollection.cs
+++ b/tests/Logging.XUnit.Tests/Integration/HttpServerCollection.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    /// <summary>
+    /// A class representing the collection fixture for an HTTP server. This class cannot be inherited.
+    /// </summary>
+    [CollectionDefinition(Name)]
+    public sealed class HttpServerCollection : ICollectionFixture<HttpServerFixture>
+    {
+        /// <summary>
+        /// The name of the test fixture.
+        /// </summary>
+        public const string Name = "HTTP server collection";
+    }
+}

--- a/tests/Logging.XUnit.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Logging.XUnit.Tests/Integration/HttpServerFixture.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SampleApp;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    /// <summary>
+    /// A test fixture representing an HTTP server hosting the sample application. This class cannot be inherited.
+    /// </summary>
+    public sealed class HttpServerFixture : WebApplicationFactory<Startup>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpServerFixture"/> class.
+        /// </summary>
+        public HttpServerFixture()
+            : base()
+        {
+            // HACK Force HTTP server startup
+            using (CreateDefaultClient())
+            {
+            }
+        }
+
+        /// <summary>
+        /// Clears the current <see cref="ITestOutputHelper"/>.
+        /// </summary>
+        public void ClearOutputHelper()
+        {
+            Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ITestOutputHelper"/> to use.
+        /// </summary>
+        /// <param name="value">The <see cref="ITestOutputHelper"/> to use.</param>
+        public void SetOutputHelper(ITestOutputHelper value)
+        {
+            Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
+        }
+
+        /// <inheritdoc />
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureLogging((p) => p.AddXUnit());
+        }
+    }
+}

--- a/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
+++ b/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for MartinCostello.Logging.XUnit.</Description>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1707</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CA2007;CA2234</NoWarn>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Logging.XUnit</RootNamespace>
     <Summary>$(Description)</Summary>
@@ -13,8 +13,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Logging.XUnit\MartinCostello.Logging.XUnit.csproj" />
+    <ProjectReference Include="..\SampleApp\SampleApp.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -18,13 +18,20 @@ namespace MartinCostello.Logging.XUnit
             // Arrange
             var builder = Mock.Of<ILoggingBuilder>();
             var outputHelper = Mock.Of<ITestOutputHelper>();
+            var accessor = Mock.Of<ITestOutputHelperAccessor>();
 
             // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit());
             Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(outputHelper));
             Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(outputHelper, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(accessor));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder).AddXUnit(accessor, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit(null as ITestOutputHelperAccessor));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit(null as ITestOutputHelperAccessor, ConfigureAction));
             Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null as ITestOutputHelper));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit(null as ITestOutputHelper, ConfigureAction));
             Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, null as Action<XUnitLoggerOptions>));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, null as Action<XUnitLoggerOptions>));
         }
 
         [Fact]

--- a/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
@@ -17,11 +17,14 @@ namespace MartinCostello.Logging.XUnit
         {
             // Arrange
             var outputHelper = Mock.Of<ITestOutputHelper>();
+            var accessor = Mock.Of<ITestOutputHelperAccessor>();
             var options = new XUnitLoggerOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLoggerProvider(null, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLoggerProvider(null as ITestOutputHelper, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLoggerProvider(null as ITestOutputHelperAccessor, options));
             Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(outputHelper, null));
+            Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(accessor, null));
         }
 
         [Fact]

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -26,7 +26,8 @@ namespace MartinCostello.Logging.XUnit
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("name", () => new XUnitLogger(null, outputHelper, options));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLogger(name, null, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLogger(name, null as ITestOutputHelper, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLogger(name, null as ITestOutputHelperAccessor, options));
 
             // Arrange
             var logger = new XUnitLogger(name, outputHelper, options);
@@ -226,6 +227,24 @@ namespace MartinCostello.Logging.XUnit
 
             // Assert
             mock.Verify((p) => p.WriteLine(It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Does_Nothing_If_No_OutputHelper()
+        {
+            // Arrange
+            string name = "MyName";
+            var accessor = Mock.Of<ITestOutputHelperAccessor>();
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+            };
+
+            var logger = new XUnitLogger(name, accessor, options);
+
+            // Act (no Assert)
+            logger.Log(LogLevel.Information, new EventId(2), "state", null, Formatter);
         }
 
         [Fact]

--- a/tests/SampleApp/Controllers/ValuesController.cs
+++ b/tests/SampleApp/Controllers/ValuesController.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace SampleApp.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ValuesController : ControllerBase
+    {
+        [HttpGet]
+        public ActionResult<IEnumerable<string>> Get()
+        {
+            return new string[] { "a", "b", "c" };
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<string> Get(string id)
+        {
+            return "value";
+        }
+
+        [HttpPost]
+        public void Post([FromBody] string value)
+        {
+        }
+
+        [HttpPut("{id}")]
+        public void Put(string id, [FromBody] string value)
+        {
+        }
+
+        [HttpDelete("{id}")]
+        public void Delete(string id)
+        {
+        }
+    }
+}

--- a/tests/SampleApp/Program.cs
+++ b/tests/SampleApp/Program.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace SampleApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                   .UseStartup<Startup>();
+    }
+}

--- a/tests/SampleApp/Properties/launchSettings.json
+++ b/tests/SampleApp/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:52657",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": false,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SampleApp": {
+      "commandName": "SampleApp",
+      "launchBrowser": false,
+      "launchUrl": "api/values",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/SampleApp/SampleApp.csproj
+++ b/tests/SampleApp/SampleApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA1801;CA1822</NoWarn>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
+  </ItemGroup>
+</Project>

--- a/tests/SampleApp/Startup.cs
+++ b/tests/SampleApp/Startup.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleApp
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvc();
+        }
+    }
+}

--- a/tests/SampleApp/appsettings.Development.json
+++ b/tests/SampleApp/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/tests/SampleApp/appsettings.json
+++ b/tests/SampleApp/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Add support for configuring the logging to support long-lived test fixtures via `ITestOutputHelperAccessor`.

Resolves #7.
