### PR TITLE
Handle exception if test has ended

### DIFF
--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -207,7 +207,16 @@ namespace MartinCostello.Logging.XUnit
             }
 
             string formatted = logBuilder.ToString();
-            outputHelper.WriteLine($"[{Clock():u}] {logLevelString}{formatted}");
+
+            try
+            {
+                outputHelper.WriteLine($"[{Clock():u}] {logLevelString}{formatted}");
+            }
+            catch (InvalidOperationException)
+            {
+                // Ignore exception if the application tries to log after the test ends
+                // but before the ITestOutputHelper is detached, e.g. "There is no currently active test."
+            }
 
             logBuilder.Clear();
 


### PR DESCRIPTION
Handle exception trying to log application shutdown if the `ITestOutputHelper` has not yet been disassociated with the application after the test ends.

For example:

![image](https://user-images.githubusercontent.com/1439341/45623075-035ef300-ba7e-11e8-9c17-17e79b75a5b6.png)
