### PR TITLE
Publish symbol packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ deploy:
   - provider: NuGet
     api_key:
       secure: 849h/efCPoqFjRMuteSC26Ao67MgmrTNX5kDuTO92eZq0S8BlKFgt0JRPvke90Oz
-    artifact: /.*\.nupkg/
+    artifact: /.*\.*nupkg/
     skip_symbols: false
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
Fix symbol packages not being included in publishes to NuGet.org which should have been included in #78.
