### PR TITLE
Remove workaround for deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.1-preview.5.g4974550fa6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,39 +28,4 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-  <!--
-    Workaround bug in generation of _LocalTopLevelSourceRoot file path.
-    See https://github.com/coverlet-coverage/coverlet/pull/863.
-  -->
-  <Target Name="ReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
-    <MSBuild Projects="@(AnnotatedProjects->'%(FullPath)')"
-             Targets="CoverletGetPathMap"
-             Properties="TargetFramework=%(AnnotatedProjects.NearestTargetFramework)"
-             SkipNonexistentTargets="true">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="_LocalTopLevelSourceRoot" />
-    </MSBuild>
-    <ItemGroup>
-      <_byProject Include="@(_LocalTopLevelSourceRoot->'%(MSBuildSourceProjectFile)')" OriginalPath="%(Identity)" />
-      <_mapping Include="@(_byProject->'%(Identity)|%(OriginalPath)=%(MappedPath)')" />
-    </ItemGroup>
-    <PropertyGroup>
-      <_sourceRootMappingFilePath>$([System.IO.Path]::Combine('$(OutputPath)', 'CoverletSourceRootsMapping'))</_sourceRootMappingFilePath>
-    </PropertyGroup>
-    <WriteLinesToFile File="$(_sourceRootMappingFilePath)" Lines="@(_mapping)"
-                      Overwrite="true" Encoding="Unicode"
-                      Condition="'@(_mapping)'!=''"
-                      WriteOnlyWhenDifferent="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_sourceRootMappingFilePath)" Condition="'@(_mapping)'!=''" />
-    </ItemGroup>
-  </Target>
-  <Target Name="CoverletGetPathMap"
-          DependsOnTargets="InitializeSourceRootMappedPaths"
-          Returns="@(_LocalTopLevelSourceRoot)"
-          Condition="'$(DeterministicSourcePaths)' == 'true'">
-    <ItemGroup>
-      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,4 +28,12 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
+  <Target Name="CoverletGetPathMap"
+          DependsOnTargets="InitializeSourceRootMappedPaths"
+          Returns="@(_LocalTopLevelSourceRoot)"
+          Condition="'$(DeterministicSourcePaths)' == 'true'">
+    <ItemGroup>
+      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="coverletNightly" value="https://www.myget.org/F/coverlet-dev/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Remove workaround for coverage not working for deterministic builds and pick up changes from coverlet-coverage/coverlet#863.
