### PR TITLE
Detect IEnumerable<KeyValuePair<string, object>> in log scopes

### DIFF
--- a/src/Logging.XUnit/XUnitLogScope.cs
+++ b/src/Logging.XUnit/XUnitLogScope.cs
@@ -17,18 +17,18 @@ namespace MartinCostello.Logging.XUnit
         private static readonly AsyncLocal<XUnitLogScope> _value = new AsyncLocal<XUnitLogScope>();
 
         /// <summary>
-        /// The state object for the scope.
-        /// </summary>
-        private readonly object _state;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="XUnitLogScope"/> class.
         /// </summary>
         /// <param name="state">The state object for the scope.</param>
         internal XUnitLogScope(object state)
         {
-            _state = state;
+            State = state;
         }
+
+        /// <summary>
+        /// Gets the state object for the scope.
+        /// </summary>
+        public object State { get; }
 
         /// <summary>
         /// Gets or sets the current scope.
@@ -46,7 +46,7 @@ namespace MartinCostello.Logging.XUnit
 
         /// <inheritdoc />
         public override string ToString()
-            => _state.ToString();
+            => State.ToString();
 
         /// <summary>
         /// Pushes a new value into the scope.

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
@@ -266,32 +267,26 @@ namespace MartinCostello.Logging.XUnit
         private static void GetScopeInformation(StringBuilder builder)
         {
             var current = XUnitLogScope.Current;
-            string scopeLog;
-            int length = builder.Length;
 
+            var stack = new Stack<XUnitLogScope>();
             while (current != null)
             {
-                foreach (var property in StringifyScope(current))
-                {
-                    if (length == builder.Length)
-                    {
-                        scopeLog = $"=> {property}";
-                    }
-                    else
-                    {
-                        scopeLog = $"=> {property} ";
-                    }
-
-                    builder.Insert(length, scopeLog);
-                }
-
+                stack.Push(current);
                 current = current.Parent;
             }
 
-            if (builder.Length > length)
+            var depth = 0;
+            string DepthPadding(int depth) => new string(' ', depth * 2);
+
+            while (stack.Any())
             {
-                builder.Insert(length, MessagePadding);
-                builder.AppendLine();
+                var elem = stack.Pop();
+                foreach (var property in StringifyScope(elem))
+                {
+                    builder.AppendLine($"{MessagePadding}{DepthPadding(depth)}=> {property}");
+                }
+
+                depth++;
             }
         }
 

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
@@ -269,16 +271,20 @@ namespace MartinCostello.Logging.XUnit
 
             while (current != null)
             {
-                if (length == builder.Length)
+                foreach (var property in StringifyScope(current))
                 {
-                    scopeLog = $"=> {current}";
-                }
-                else
-                {
-                    scopeLog = $"=> {current} ";
+                    if (length == builder.Length)
+                    {
+                        scopeLog = $"=> {property}";
+                    }
+                    else
+                    {
+                        scopeLog = $"=> {property} ";
+                    }
+
+                    builder.Insert(length, scopeLog);
                 }
 
-                builder.Insert(length, scopeLog);
                 current = current.Parent;
             }
 
@@ -286,6 +292,33 @@ namespace MartinCostello.Logging.XUnit
             {
                 builder.Insert(length, MessagePadding);
                 builder.AppendLine();
+            }
+        }
+
+        /// <summary>
+        /// Returns one or more stringified properties from the log scope.
+        /// </summary>
+        /// <param name="scope">The <see cref="XUnitLogScope"/> to stringify.</param>
+        /// <returns>An enumeration of scope properties from the current scope.</returns>
+        private static IEnumerable<string> StringifyScope(XUnitLogScope scope)
+        {
+            if (scope.State is IEnumerable<KeyValuePair<string, object>> pairs)
+            {
+                foreach (var pair in pairs)
+                {
+                    yield return $"{pair.Key}: {pair.Value}";
+                }
+            }
+            else if (scope.State is IEnumerable<string> entries)
+            {
+                foreach (var entry in entries)
+                {
+                    yield return entry;
+                }
+            }
+            else
+            {
+                yield return scope.ToString();
             }
         }
     }

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -276,14 +276,18 @@ namespace MartinCostello.Logging.XUnit
             }
 
             var depth = 0;
-            string DepthPadding(int depth) => new string(' ', depth * 2);
+            static string DepthPadding(int depth) => new string(' ', depth * 2);
 
-            while (stack.Any())
+            while (stack.Count > 0)
             {
                 var elem = stack.Pop();
                 foreach (var property in StringifyScope(elem))
                 {
-                    builder.AppendLine($"{MessagePadding}{DepthPadding(depth)}=> {property}");
+                    builder.Append(MessagePadding)
+                           .Append(DepthPadding(depth))
+                           .Append("=> ")
+                           .Append(property)
+                           .AppendLine();
                 }
 
                 depth++;
@@ -301,7 +305,7 @@ namespace MartinCostello.Logging.XUnit
             {
                 foreach (var pair in pairs)
                 {
-                    yield return $"{pair.Key}: {pair.Value}";
+                    yield return pair.Key + ": " + pair.Value;
                 }
             }
             else if (scope.State is IEnumerable<string> entries)

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -501,7 +501,9 @@ namespace MartinCostello.Logging.XUnit
 
             string expected = string.Join(
                 Environment.NewLine,
-                new[] { "[2018-08-19 16:12:16Z] info: MyName[0]", "      => ScopeKey: ScopeValue", "      Message|False|False" });
+                "[2018-08-19 16:12:16Z] info: MyName[0]",
+                "      => ScopeKey: ScopeValue",
+                "      Message|False|False");
 
             // Act
             using (logger.BeginScope(new[]

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -615,6 +615,44 @@ namespace MartinCostello.Logging.XUnit
             mock.Verify((p) => p.WriteLine(expected), Times.Once());
         }
 
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Scopes_Included_And_There_Is_Scope_Of_IEnumerable()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+                IncludeScopes = true,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            string expected = string.Join(
+                Environment.NewLine,
+                "[2018-08-19 16:12:16Z] info: MyName[0]",
+                "      => ScopeKeyOne",
+                "      => ScopeKeyTwo",
+                "      => ScopeKeyThree",
+                "      Message|False|False");
+
+            // Act
+            using (logger.BeginScope(new[] { "ScopeKeyOne", "ScopeKeyTwo", "ScopeKeyThree" }))
+            {
+                logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+            }
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
         private static DateTimeOffset StaticClock() => new DateTimeOffset(2018, 08, 19, 17, 12, 16, TimeSpan.FromHours(1));
 
         private static bool FilterTrue(string categoryName, LogLevel level) => true;

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Shouldly;
@@ -467,6 +468,82 @@ namespace MartinCostello.Logging.XUnit
                         }
                     }
                 }
+            }
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Scopes_Included_And_There_Is_Scope_Of_KeyValuePair()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+                IncludeScopes = true,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { "[2018-08-19 16:12:16Z] info: MyName[0]", "      => ScopeKey: ScopeValue", "      Message|False|False" });
+
+            // Act
+            using (logger.BeginScope(new[]
+            {
+                new KeyValuePair<string, object>("ScopeKey", "ScopeValue"),
+            }))
+            {
+                logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+            }
+
+            // Assert
+            mock.Verify((p) => p.WriteLine(expected), Times.Once());
+        }
+
+        [Fact]
+        public static void XUnitLogger_Log_Logs_Message_If_Scopes_Included_And_There_Is_Scope_Of_KeyValuePairs()
+        {
+            // Arrange
+            var mock = new Mock<ITestOutputHelper>();
+
+            string name = "MyName";
+            var outputHelper = mock.Object;
+
+            var options = new XUnitLoggerOptions()
+            {
+                Filter = FilterTrue,
+                IncludeScopes = true,
+            };
+
+            var logger = new XUnitLogger(name, outputHelper, options)
+            {
+                Clock = StaticClock,
+            };
+
+            string expected = string.Join(
+                Environment.NewLine,
+                new[] { "[2018-08-19 16:12:16Z] info: MyName[0]", "      => ScopeKeyThree: ScopeValueThree => ScopeKeyTwo: ScopeValueTwo => ScopeKeyOne: ScopeValueOne", "      Message|False|False" });
+
+            // Act
+            using (logger.BeginScope(new[]
+            {
+                new KeyValuePair<string, object>("ScopeKeyOne", "ScopeValueOne"),
+                new KeyValuePair<string, object>("ScopeKeyTwo", "ScopeValueTwo"),
+                new KeyValuePair<string, object>("ScopeKeyThree", "ScopeValueThree"),
+            }))
+            {
+                logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
             }
 
             // Assert


### PR DESCRIPTION
This PR implements a potential solution from issue https://github.com/martincostello/xunit-logging/issues/214. 

Instead of rendering `=> System.Collections.Generic.KeyValuePair2[System.String,System.Object][]` for scope objects of this type, it renders this:

```
[2018-08-19 16:12:16Z] info: MyName[0]
      => ScopeKeyOne: ScopeValueOne
      => ScopeKeyTwo: ScopeValueTwo
      => ScopeKeyThree: ScopeValueThree
        => ScopeKeyFour: ScopeValueFour
        => ScopeKeyFive: ScopeValueFive
        => ScopeKeySix: ScopeValueSix
      Message|False|False
```

given this log message:

```csharp
using (logger.BeginScope(new[]
{
    new KeyValuePair<string, object>("ScopeKeyOne", "ScopeValueOne"),
    new KeyValuePair<string, object>("ScopeKeyTwo", "ScopeValueTwo"),
    new KeyValuePair<string, object>("ScopeKeyThree", "ScopeValueThree"),
}))
{
    using (logger.BeginScope(new[]
    {
        new KeyValuePair<string, object>("ScopeKeyFour", "ScopeValueFour"),
        new KeyValuePair<string, object>("ScopeKeyFive", "ScopeValueFive"),
        new KeyValuePair<string, object>("ScopeKeySix", "ScopeValueSix"),
    }))
    {
        logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
    }
}
```