### PR TITLE
Use coverlet.msbuild only in test project

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,39 +28,4 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-  <!--
-    Workaround bug in generation of _LocalTopLevelSourceRoot file path.
-    See https://github.com/coverlet-coverage/coverlet/pull/863.
-  -->
-  <Target Name="ReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
-    <MSBuild Projects="@(AnnotatedProjects->'%(FullPath)')"
-             Targets="CoverletGetPathMap"
-             Properties="TargetFramework=%(AnnotatedProjects.NearestTargetFramework)"
-             SkipNonexistentTargets="true">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="_LocalTopLevelSourceRoot" />
-    </MSBuild>
-    <ItemGroup>
-      <_byProject Include="@(_LocalTopLevelSourceRoot->'%(MSBuildSourceProjectFile)')" OriginalPath="%(Identity)" />
-      <_mapping Include="@(_byProject->'%(Identity)|%(OriginalPath)=%(MappedPath)')" />
-    </ItemGroup>
-    <PropertyGroup>
-      <_sourceRootMappingFilePath>$([System.IO.Path]::Combine('$(OutputPath)', 'CoverletSourceRootsMapping'))</_sourceRootMappingFilePath>
-    </PropertyGroup>
-    <WriteLinesToFile File="$(_sourceRootMappingFilePath)" Lines="@(_mapping)"
-                      Overwrite="true" Encoding="Unicode"
-                      Condition="'@(_mapping)'!=''"
-                      WriteOnlyWhenDifferent="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_sourceRootMappingFilePath)" Condition="'@(_mapping)'!=''" />
-    </ItemGroup>
-  </Target>
-  <Target Name="CoverletGetPathMap"
-          DependsOnTargets="InitializeSourceRootMappedPaths"
-          Returns="@(_LocalTopLevelSourceRoot)"
-          Condition="'$(DeterministicSourcePaths)' == 'true'">
-    <ItemGroup>
-      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />


### PR DESCRIPTION
Adding a package reference in a non-test project would lead to this error when running `dotnet test` in the repository root:
> ~/.nuget/packages/coverlet.msbuild/3.0.3/build/coverlet.msbuild.targets(70,5): error MSB4044: The "Coverlet.MSbuild.Tasks.CoverageResultTask" task was not given a value for the required parameter "InstrumenterState".

See https://github.com/coverlet-coverage/coverlet/issues/480#issuecomment-515864660

Also delete the workaround for the bug in generation of _LocalTopLevelSourceRoot which is [no longer necessary](https://github.com/coverlet-coverage/coverlet/pull/863).