### PR TITLE
Remove SetCompatibilityVersion()

### DIFF
--- a/Logging.XUnit.ruleset
+++ b/Logging.XUnit.ruleset
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Logging.XUnit Rules" Description="This rule set contains rules for the Logging.XUnit solution." ToolsVersion="15.0">
+<RuleSet Name="Logging.XUnit Rules" Description="This rule set contains rules for the Logging.XUnit solution." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1303" Action="None" />

--- a/tests/SampleApp/Startup.cs
+++ b/tests/SampleApp/Startup.cs
@@ -21,7 +21,7 @@ namespace SampleApp
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
         }
 
         public void Configure(IApplicationBuilder app, IHostEnvironment env)


### PR DESCRIPTION
Remove redundant call to `SetCompatibilityVersion()` that is also obsolete in .NET 6 (see #205).

