### PR TITLE
Add support for IMessageSink

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' != 'true' ">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.1" />
+    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,8 +11,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' != 'true' ">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageVersion Include="xunit.abstractions" Version="2.0.2" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/src/Logging.XUnit/IMessageSinkAccessor.cs
+++ b/src/Logging.XUnit/IMessageSinkAccessor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// Defines a property for accessing an <see cref="IMessageSink"/>.
+    /// </summary>
+    public interface IMessageSinkAccessor
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IMessageSink"/> to use.
+        /// </summary>
+        IMessageSink? MessageSink { get; set; }
+    }
+}

--- a/src/Logging.XUnit/IMessageSinkExtensions.cs
+++ b/src/Logging.XUnit/IMessageSinkExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+
+namespace Xunit.Abstractions
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="IMessageSink"/> interface. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class IMessageSinkExtensions
+    {
+        /// <summary>
+        /// Returns an <see cref="ILoggerFactory"/> that logs to the message sink.
+        /// </summary>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to create the logger factory from.</param>
+        /// <returns>
+        /// An <see cref="ILoggerFactory"/> that writes messages to the message sink.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory ToLoggerFactory(this IMessageSink messageSink)
+        {
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            return new LoggerFactory().AddXUnit(messageSink);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="ILogger{T}"/> that logs to the message sink.
+        /// </summary>
+        /// <typeparam name="T">The type of the logger to create.</typeparam>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to create the logger from.</param>
+        /// <returns>
+        /// An <see cref="ILogger{T}"/> that writes messages to the message sink.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILogger<T> ToLogger<T>(this IMessageSink messageSink)
+            => messageSink.ToLoggerFactory().CreateLogger<T>();
+    }
+}

--- a/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
+++ b/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
@@ -17,5 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="xunit.abstractions" />
+    <PackageReference Include="xunit.extensibility.execution" />
   </ItemGroup>
 </Project>

--- a/src/Logging.XUnit/MessageSinkAccessor.cs
+++ b/src/Logging.XUnit/MessageSinkAccessor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing the default implementation of <see cref="IMessageSinkAccessor"/>. This class cannot be inherited.
+    /// </summary>
+    internal sealed class MessageSinkAccessor : IMessageSinkAccessor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageSinkAccessor"/> class.
+        /// </summary>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        internal MessageSinkAccessor(IMessageSink messageSink)
+        {
+            MessageSink = messageSink ?? throw new ArgumentNullException(nameof(messageSink));
+        }
+
+        /// <summary>
+        /// Gets or sets the current <see cref="IMessageSink"/>.
+        /// </summary>
+        public IMessageSink? MessageSink { get; set; }
+    }
+}

--- a/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing an <see cref="ILogger"/> to use with xunit.
+    /// </summary>
+    public partial class XUnitLogger
+    {
+        /// <summary>
+        /// The <see cref="IMessageSinkAccessor"/> to use. This field is read-only.
+        /// </summary>
+        private readonly IMessageSinkAccessor? _messageSinkAccessor;
+
+        /// <summary>
+        /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
+        /// </summary>
+        private Func<string, IMessageSinkMessage> _messageSinkMessageFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLogger"/> class.
+        /// </summary>
+        /// <param name="name">The name for messages produced by the logger.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="options">The <see cref="XUnitLoggerOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="name"/> or <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLogger(string name, IMessageSink messageSink, XUnitLoggerOptions? options)
+            : this(name, new MessageSinkAccessor(messageSink), options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLogger"/> class.
+        /// </summary>
+        /// <param name="name">The name for messages produced by the logger.</param>
+        /// <param name="accessor">The <see cref="IMessageSinkAccessor"/> to use.</param>
+        /// <param name="options">The <see cref="XUnitLoggerOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="name"/> or <paramref name="accessor"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLogger(string name, IMessageSinkAccessor accessor, XUnitLoggerOptions? options)
+            : this(name, options)
+        {
+            _messageSinkAccessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+        }
+
+        /// <summary>
+        /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="value"/> is <see langword="null"/>.
+        /// </exception>
+        public Func<string, IMessageSinkMessage> MessageSinkMessageFactory
+        {
+            get { return _messageSinkMessageFactory; }
+            set { _messageSinkMessageFactory = value ?? throw new ArgumentNullException(nameof(value)); }
+        }
+    }
+}

--- a/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
@@ -18,7 +18,7 @@ namespace MartinCostello.Logging.XUnit
         private readonly IMessageSinkAccessor? _messageSinkAccessor;
 
         /// <summary>
-        /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
+        /// Gets or sets the message sink message factory to use when writing to an <see cref="IMessageSink"/>.
         /// </summary>
         private Func<string, IMessageSinkMessage> _messageSinkMessageFactory;
 

--- a/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLogger.IMessageSink.cs
@@ -52,7 +52,7 @@ namespace MartinCostello.Logging.XUnit
         }
 
         /// <summary>
-        /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
+        /// Gets or sets the message sink message factory to use when writing to an <see cref="IMessageSink"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="value"/> is <see langword="null"/>.

--- a/src/Logging.XUnit/XUnitLogger.ITestOutputHelper.cs
+++ b/src/Logging.XUnit/XUnitLogger.ITestOutputHelper.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing an <see cref="ILogger"/> to use with xunit.
+    /// </summary>
+    public partial class XUnitLogger
+    {
+        /// <summary>
+        /// The <see cref="ITestOutputHelperAccessor"/> to use. This field is read-only.
+        /// </summary>
+        private readonly ITestOutputHelperAccessor? _outputHelperAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLogger"/> class.
+        /// </summary>
+        /// <param name="name">The name for messages produced by the logger.</param>
+        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to use.</param>
+        /// <param name="options">The <see cref="XUnitLoggerOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="name"/> or <paramref name="outputHelper"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLogger(string name, ITestOutputHelper outputHelper, XUnitLoggerOptions? options)
+            : this(name, new TestOutputHelperAccessor(outputHelper), options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLogger"/> class.
+        /// </summary>
+        /// <param name="name">The name for messages produced by the logger.</param>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
+        /// <param name="options">The <see cref="XUnitLoggerOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="name"/> or <paramref name="accessor"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLogger(string name, ITestOutputHelperAccessor accessor, XUnitLoggerOptions? options)
+            : this(name, options)
+        {
+            _outputHelperAccessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+        }
+    }
+}

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -136,6 +136,14 @@ namespace MartinCostello.Logging.XUnit
         /// <param name="exception">The exception related to this message.</param>
         public virtual void WriteMessage(LogLevel logLevel, int eventId, string? message, Exception? exception)
         {
+            ITestOutputHelper? outputHelper = _outputHelperAccessor?.OutputHelper;
+            IMessageSink? messageSink = _messageSinkAccessor?.MessageSink;
+
+            if (outputHelper is null && messageSink is null)
+            {
+                return;
+            }
+
             StringBuilder? logBuilder = _logBuilder;
             _logBuilder = null;
 
@@ -182,9 +190,6 @@ namespace MartinCostello.Logging.XUnit
 
             try
             {
-                ITestOutputHelper? outputHelper = _outputHelperAccessor?.OutputHelper;
-                IMessageSink? messageSink = _messageSinkAccessor?.MessageSink;
-
                 var line = $"[{Clock():u}] {logLevelString}{formatted}";
                 if (outputHelper != null)
                 {

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -198,7 +198,7 @@ namespace MartinCostello.Logging.XUnit
 
                 if (messageSink != null)
                 {
-                    var sinkMessage = MessageSinkMessageFactory(line);
+                    var sinkMessage = _messageSinkMessageFactory(line);
                     messageSink.OnMessage(sinkMessage);
                 }
             }

--- a/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Extensions.Logging
         /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="factory"/>, <paramref name="messageSink"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// <paramref name="factory"/>, <paramref name="messageSink"/> or <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
         {

--- a/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Logging
         /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="builder"/>, <paramref name="accessor"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// <paramref name="builder"/>, <paramref name="accessor"/> or <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSinkAccessor accessor, Action<XUnitLoggerOptions> configure)
         {

--- a/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
@@ -1,0 +1,342 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using MartinCostello.Logging.XUnit;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// A class containing extension methods for configuring logging to xunit. This class cannot be inherited.
+    /// </summary>
+    public static partial class XUnitLoggerExtensions
+    {
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="accessor">The <see cref="IMessageSinkAccessor"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="accessor"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSinkAccessor accessor)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (accessor == null)
+            {
+                throw new ArgumentNullException(nameof(accessor));
+            }
+
+            return builder.AddXUnit(accessor, (_) => { });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="accessor">The <see cref="IMessageSinkAccessor"/> to use.</param>
+        /// <param name="configure">A delegate to a method to use to configure the logging options.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/>, <paramref name="accessor"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSinkAccessor accessor, Action<XUnitLoggerOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (accessor == null)
+            {
+                throw new ArgumentNullException(nameof(accessor));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var options = new XUnitLoggerOptions();
+
+            configure(options);
+
+#pragma warning disable CA2000
+            builder.AddProvider(new XUnitLoggerProvider(accessor, options));
+#pragma warning restore CA2000
+
+            builder.Services.TryAddSingleton(accessor);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink messageSink)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            return builder.AddXUnit(messageSink, (_) => { });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the logging builder.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="configure">A delegate to a method to use to configure the logging options.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/>, <paramref name="messageSink"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var options = new XUnitLoggerOptions();
+
+            configure(options);
+
+#pragma warning disable CA2000
+            return builder.AddProvider(new XUnitLoggerProvider(messageSink, options));
+#pragma warning restore CA2000
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/> or <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, LogLevel minLevel)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            return factory.AddXUnit(messageSink, (_, level) => level >= minLevel);
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="filter">The category filter to apply to logs.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/>, <paramref name="messageSink"/> or <paramref name="filter"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Func<string?, LogLevel, bool> filter)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
+
+            return factory.AddXUnit(messageSink, (options) => options.Filter = filter);
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/> or <paramref name="messageSink"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            return factory.AddXUnit(messageSink, (_) => { });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/>, <paramref name="messageSink"/> OR <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, XUnitLoggerOptions options)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return factory.AddXUnit(messageSink, () => options);
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="configure">A delegate to a method to use to configure the logging options.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/>, <paramref name="messageSink"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return factory.AddXUnit(
+                messageSink,
+                () =>
+                {
+                    var options = new XUnitLoggerOptions();
+                    configure(options);
+                    return options;
+                });
+        }
+
+        /// <summary>
+        /// Adds an xunit logger to the factory.
+        /// </summary>
+        /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="configure">A delegate to a method that returns a configured <see cref="XUnitLoggerOptions"/> to use.</param>
+        /// <returns>
+        /// The instance of <see cref="ILoggerFactory"/> specified by <paramref name="factory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="factory"/>, <paramref name="messageSink"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Func<XUnitLoggerOptions> configure)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var options = configure();
+
+#pragma warning disable CA2000
+            factory.AddProvider(new XUnitLoggerProvider(messageSink, options));
+#pragma warning restore CA2000
+
+            return factory;
+        }
+    }
+}

--- a/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Logging
         /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="builder"/>, <paramref name="messageSink"/> OR <paramref name="configure"/> is <see langword="null"/>.
+        /// <paramref name="builder"/>, <paramref name="messageSink"/> or <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
         {

--- a/src/Logging.XUnit/XUnitLoggerExtensions.ITestOutputHelper.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.ITestOutputHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging
     /// A class containing extension methods for configuring logging to xunit. This class cannot be inherited.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class XUnitLoggerExtensions
+    public static partial class XUnitLoggerExtensions
     {
         /// <summary>
         /// Adds an xunit logger to the logging builder.

--- a/src/Logging.XUnit/XUnitLoggerOptions.cs
+++ b/src/Logging.XUnit/XUnitLoggerOptions.cs
@@ -27,7 +27,6 @@ namespace MartinCostello.Logging.XUnit
 
         /// <summary>
         /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
-        /// By default, creates a <see cref="DiagnosticMessage"/>.
         /// </summary>
         public Func<string, IMessageSinkMessage> MessageSinkMessageFactory { get; set; } = m => new DiagnosticMessage(m);
 

--- a/src/Logging.XUnit/XUnitLoggerOptions.cs
+++ b/src/Logging.XUnit/XUnitLoggerOptions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace MartinCostello.Logging.XUnit
 {
@@ -22,6 +24,12 @@ namespace MartinCostello.Logging.XUnit
         /// Gets or sets the category filter to apply to logs.
         /// </summary>
         public Func<string?, LogLevel, bool> Filter { get; set; } = (c, l) => true; // By default log everything
+
+        /// <summary>
+        /// Gets or sets the message sink message factory to use when writing to a <see cref="IMessageSink"/>.
+        /// By default, creates a <see cref="DiagnosticMessage"/>.
+        /// </summary>
+        public Func<string, IMessageSinkMessage> MessageSinkMessageFactory { get; set; } = m => new DiagnosticMessage(m);
 
         /// <summary>
         /// Gets or sets a value indicating whether to include scopes.

--- a/src/Logging.XUnit/XUnitLoggerProvider.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.IMessageSink.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing an <see cref="ILoggerProvider"/> to use with xunit.
+    /// </summary>
+    public partial class XUnitLoggerProvider
+    {
+        /// <summary>
+        /// The <see cref="IMessageSinkAccessor"/> to use. This field is readonly.
+        /// </summary>
+        private readonly IMessageSinkAccessor? _messageSinkAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="messageSink">The <see cref="IMessageSink"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="messageSink"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLoggerProvider(IMessageSink messageSink, XUnitLoggerOptions options)
+            : this(new MessageSinkAccessor(messageSink), options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="accessor">The <see cref="IMessageSinkAccessor"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="accessor"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLoggerProvider(IMessageSinkAccessor accessor, XUnitLoggerOptions options)
+        {
+            _messageSinkAccessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+    }
+}

--- a/src/Logging.XUnit/XUnitLoggerProvider.ITestOutputHelper.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.ITestOutputHelper.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit
+{
+    /// <summary>
+    /// A class representing an <see cref="ILoggerProvider"/> to use with xunit.
+    /// </summary>
+    public partial class XUnitLoggerProvider
+    {
+        /// <summary>
+        /// The <see cref="ITestOutputHelperAccessor"/> to use. This field is readonly.
+        /// </summary>
+        private readonly ITestOutputHelperAccessor? _outputHelperAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="outputHelper"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLoggerProvider(ITestOutputHelper outputHelper, XUnitLoggerOptions options)
+            : this(new TestOutputHelperAccessor(outputHelper), options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
+        /// <param name="options">The options to use for logging to xunit.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="accessor"/> or <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public XUnitLoggerProvider(ITestOutputHelperAccessor accessor, XUnitLoggerOptions options)
+        {
+            _outputHelperAccessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+    }
+}

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -10,44 +10,12 @@ namespace MartinCostello.Logging.XUnit
     /// <summary>
     /// A class representing an <see cref="ILoggerProvider"/> to use with xunit.
     /// </summary>
-    public class XUnitLoggerProvider : ILoggerProvider
+    public partial class XUnitLoggerProvider : ILoggerProvider
     {
-        /// <summary>
-        /// The <see cref="ITestOutputHelperAccessor"/> to use. This field is readonly.
-        /// </summary>
-        private readonly ITestOutputHelperAccessor _accessor;
-
         /// <summary>
         /// The <see cref="XUnitLoggerOptions"/> to use. This field is readonly.
         /// </summary>
         private readonly XUnitLoggerOptions _options;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
-        /// </summary>
-        /// <param name="outputHelper">The <see cref="ITestOutputHelper"/> to use.</param>
-        /// <param name="options">The options to use for logging to xunit.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="outputHelper"/> or <paramref name="options"/> is <see langword="null"/>.
-        /// </exception>
-        public XUnitLoggerProvider(ITestOutputHelper outputHelper, XUnitLoggerOptions options)
-            : this(new TestOutputHelperAccessor(outputHelper), options)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.
-        /// </summary>
-        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> to use.</param>
-        /// <param name="options">The options to use for logging to xunit.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="accessor"/> or <paramref name="options"/> is <see langword="null"/>.
-        /// </exception>
-        public XUnitLoggerProvider(ITestOutputHelperAccessor accessor, XUnitLoggerOptions options)
-        {
-            _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-        }
 
         /// <summary>
         /// Finalizes an instance of the <see cref="XUnitLoggerProvider"/> class.
@@ -58,7 +26,20 @@ namespace MartinCostello.Logging.XUnit
         }
 
         /// <inheritdoc />
-        public virtual ILogger CreateLogger(string categoryName) => new XUnitLogger(categoryName, _accessor, _options);
+        public virtual ILogger CreateLogger(string categoryName)
+        {
+            if (_outputHelperAccessor != null)
+            {
+                return new XUnitLogger(categoryName, _outputHelperAccessor, _options);
+            }
+
+            if (_messageSinkAccessor != null)
+            {
+                return new XUnitLogger(categoryName, _messageSinkAccessor, _options);
+            }
+
+            throw new InvalidOperationException($"Either {nameof(_outputHelperAccessor)} or {nameof(_messageSinkAccessor)} must not be null.");
+        }
 
         /// <inheritdoc />
         public void Dispose()

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -38,7 +38,7 @@ namespace MartinCostello.Logging.XUnit
                 return new XUnitLogger(categoryName, _messageSinkAccessor, _options);
             }
 
-            throw new InvalidOperationException($"Either {nameof(_outputHelperAccessor)} or {nameof(_messageSinkAccessor)} must not be null.");
+            throw new InvalidOperationException("INTERNAL ERROR. This code path is not reachable since XUnitLoggerProvider is initialized with either a non null _outputHelperAccessor or a non null _messageSinkAccessor.");
         }
 
         /// <inheritdoc />

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace MartinCostello.Logging.XUnit
 {

--- a/tests/Logging.XUnit.Tests/Constructor.cs
+++ b/tests/Logging.XUnit.Tests/Constructor.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Logging.XUnit
+{
+    public enum Constructor
+    {
+        ITestOutputHelper,
+        IMessageSink,
+    }
+}

--- a/tests/Logging.XUnit.Tests/Integration/DatabaseFixture.cs
+++ b/tests/Logging.XUnit.Tests/Integration/DatabaseFixture.cs
@@ -11,29 +11,29 @@ namespace MartinCostello.Logging.XUnit.Integration
 {
     public sealed class DatabaseFixture : IAsyncLifetime
     {
-        private readonly ILogger _loggerInitialize;
-        private readonly ILogger _loggerDispose;
+        private readonly ILogger _initializeLogger;
+        private readonly ILogger _disposeLogger;
         private string? _connectionString;
 
         public DatabaseFixture(IMessageSink messageSink)
         {
             using var loggerFactory = new LoggerFactory();
-            _loggerInitialize = loggerFactory.AddXUnit(messageSink, c => c.MessageSinkMessageFactory = m => new PrintableDiagnosticMessage(m)).CreateLogger<DatabaseFixture>();
-            _loggerDispose = messageSink.ToLogger<DatabaseFixture>();
+            _initializeLogger = loggerFactory.AddXUnit(messageSink, c => c.MessageSinkMessageFactory = m => new PrintableDiagnosticMessage(m)).CreateLogger<DatabaseFixture>();
+            _disposeLogger = messageSink.ToLogger<DatabaseFixture>();
         }
 
         public string ConnectionString => _connectionString ?? throw new InvalidOperationException("The connection string is only available after InitializeAsync has completed.");
 
         Task IAsyncLifetime.InitializeAsync()
         {
-            _loggerInitialize.LogInformation("Initializing database");
+            _initializeLogger.LogInformation("Initializing database");
             _connectionString = "Server=localhost";
             return Task.CompletedTask;
         }
 
         Task IAsyncLifetime.DisposeAsync()
         {
-            _loggerDispose.LogInformation("Disposing database");
+            _disposeLogger.LogInformation("Disposing database");
             return Task.CompletedTask;
         }
     }

--- a/tests/Logging.XUnit.Tests/Integration/DatabaseFixture.cs
+++ b/tests/Logging.XUnit.Tests/Integration/DatabaseFixture.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    public sealed class DatabaseFixture : IAsyncLifetime
+    {
+        private readonly ILogger _loggerInitialize;
+        private readonly ILogger _loggerDispose;
+        private string? _connectionString;
+
+        public DatabaseFixture(IMessageSink messageSink)
+        {
+            using var loggerFactory = new LoggerFactory();
+            _loggerInitialize = loggerFactory.AddXUnit(messageSink, c => c.MessageSinkMessageFactory = m => new PrintableDiagnosticMessage(m)).CreateLogger<DatabaseFixture>();
+            _loggerDispose = messageSink.ToLogger<DatabaseFixture>();
+        }
+
+        public string ConnectionString => _connectionString ?? throw new InvalidOperationException("The connection string is only available after InitializeAsync has completed.");
+
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            _loggerInitialize.LogInformation("Initializing database");
+            _connectionString = "Server=localhost";
+            return Task.CompletedTask;
+        }
+
+        Task IAsyncLifetime.DisposeAsync()
+        {
+            _loggerDispose.LogInformation("Disposing database");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Logging.XUnit.Tests/Integration/DatabaseTests.cs
+++ b/tests/Logging.XUnit.Tests/Integration/DatabaseTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Shouldly;
+using Xunit;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    public class DatabaseTests : IClassFixture<DatabaseFixture>
+    {
+        public DatabaseTests(DatabaseFixture databaseFixture)
+        {
+            DatabaseFixture = databaseFixture;
+        }
+
+        public DatabaseFixture DatabaseFixture { get; }
+
+        [Fact]
+        public void Run_Database_Test()
+        {
+            DatabaseFixture.ConnectionString.ShouldNotBeEmpty();
+        }
+    }
+}

--- a/tests/Logging.XUnit.Tests/Integration/PrintableDiagnosticMessage.cs
+++ b/tests/Logging.XUnit.Tests/Integration/PrintableDiagnosticMessage.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace MartinCostello.Logging.XUnit.Integration
+{
+    /// <summary>
+    /// See https://github.com/xunit/xunit/pull/2148#issuecomment-839838421
+    /// </summary>
+    internal class PrintableDiagnosticMessage : DiagnosticMessage
+    {
+        public PrintableDiagnosticMessage(string message)
+            : base(message)
+        {
+        }
+
+        public override string ToString() => Message;
+    }
+}

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -121,6 +123,83 @@ namespace MartinCostello.Logging.XUnit
             // Act and Assert
             Assert.Throws<ArgumentNullException>("outputHelper", () => outputHelper!.ToLoggerFactory());
             Assert.Throws<ArgumentNullException>("messageSink", () => messageSink!.ToLoggerFactory());
+        }
+
+        [Fact]
+        public static void AddXUnit_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddLogging(c => c.AddXUnit());
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
+            serviceProvider.GetService<ITestOutputHelperAccessor>().ShouldBeOfType<AmbientTestOutputHelperAccessor>();
+        }
+
+        [Fact]
+        public static void AddXUnit_ITestOutputHelperAccessor_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var accessor = Mock.Of<ITestOutputHelperAccessor>();
+
+            // Act
+            services.AddLogging(c => c.AddXUnit(accessor));
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
+            serviceProvider.GetService<ITestOutputHelperAccessor>().ShouldBe(accessor);
+        }
+
+        [Fact]
+        public static void AddXUnit_IMessageSinkAccessor_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var accessor = Mock.Of<IMessageSinkAccessor>();
+
+            // Act
+            services.AddLogging(c => c.AddXUnit(accessor));
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
+            serviceProvider.GetService<IMessageSinkAccessor>().ShouldBe(accessor);
+        }
+
+        [Fact]
+        public static void AddXUnit_ITestOutputHelper_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var testOutputHelper = Mock.Of<ITestOutputHelper>();
+
+            // Act
+            services.AddLogging(c => c.AddXUnit(testOutputHelper));
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
+        }
+
+        [Fact]
+        public static void AddXUnit_IMessageSink_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var messageSink = Mock.Of<IMessageSink>();
+
+            // Act
+            services.AddLogging(c => c.AddXUnit(messageSink));
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
         }
 
         private static void ConfigureAction(XUnitLoggerOptions options)

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace MartinCostello.Logging.XUnit
     public static class XUnitLoggerExtensionsTests
     {
         [Fact]
-        public static void AddXUnit_For_ILoggerBuilder_Validates_Parameters()
+        public static void AddXUnit_TestOutputHelper_For_ILoggerBuilder_Validates_Parameters()
         {
             // Arrange
             var builder = Mock.Of<ILoggingBuilder>();
@@ -35,7 +35,28 @@ namespace MartinCostello.Logging.XUnit
         }
 
         [Fact]
-        public static void AddXUnit_For_ILoggerFactory_Validates_Parameters()
+        public static void AddXUnit_MessageSink_For_ILoggerBuilder_Validates_Parameters()
+        {
+            // Arrange
+            var builder = Mock.Of<ILoggingBuilder>();
+            var messageSink = Mock.Of<IMessageSink>();
+            var accessor = Mock.Of<IMessageSinkAccessor>();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(messageSink));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(messageSink, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor) !));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor) !, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink) !));
+            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink) !, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>) !));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>) !));
+        }
+
+        [Fact]
+        public static void AddXUnit_TestOutputHelper_For_ILoggerFactory_Validates_Parameters()
         {
             // Arrange
             ILoggerFactory factory = NullLoggerFactory.Instance;
@@ -51,11 +72,11 @@ namespace MartinCostello.Logging.XUnit
             Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, Filter));
             Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, logLevel));
             Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null!, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null!, ConfigureFunction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null!, Filter));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null!, logLevel));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit(null!, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, Filter));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, logLevel));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, options));
             Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(outputHelper, (null as XUnitLoggerOptions) !));
             Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>) !));
             Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Func<XUnitLoggerOptions>) !));
@@ -63,13 +84,43 @@ namespace MartinCostello.Logging.XUnit
         }
 
         [Fact]
+        public static void AddXUnit_MessageSink_For_ILoggerFactory_Validates_Parameters()
+        {
+            // Arrange
+            ILoggerFactory factory = NullLoggerFactory.Instance;
+            var logLevel = LogLevel.Information;
+            var messageSink = Mock.Of<IMessageSink>();
+            var options = new XUnitLoggerOptions();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, options));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, Filter));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, logLevel));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, Filter));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, logLevel));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, options));
+            Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(messageSink, (null as XUnitLoggerOptions) !));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>) !));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Func<XUnitLoggerOptions>) !));
+            Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(messageSink, (null as Func<string, LogLevel, bool>) !));
+        }
+
+        [Fact]
         public static void ToLoggerFactory_Validates_Parameters()
         {
             // Arrange
             ITestOutputHelper? outputHelper = null;
+            IMessageSink? messageSink = null;
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("outputHelper", () => outputHelper!.ToLoggerFactory());
+            Assert.Throws<ArgumentNullException>("messageSink", () => messageSink!.ToLoggerFactory());
         }
 
         private static void ConfigureAction(XUnitLoggerOptions options)

--- a/tests/Logging.XUnit.Tests/xunit.runner.json
+++ b/tests/Logging.XUnit.Tests/xunit.runner.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true,
   "methodDisplay": "method",
   "methodDisplayOptions": "replaceUnderscoreWithSpace"
 }


### PR DESCRIPTION
This enables logging in extensibility classes such as fixtures and discoverers. See https://xunit.net/docs/capturing-output#output-in-extensions for more information.

All classes were modeled after the similar classes for `ITestOutputHelper`. The only method impossible to replicate was `public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder)`.