### PR TITLE
Increase test coverage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,8 +36,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <VersionPrefix>0.1.3</VersionPrefix>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Moq" Version="4.16.1" />
     <PackageVersion Include="ReportGenerator" Version="4.8.13" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.354" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' != 'true' ">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="2.0.0" />

--- a/src/Logging.XUnit/XUnitLogger.cs
+++ b/src/Logging.XUnit/XUnitLogger.cs
@@ -25,7 +25,7 @@ namespace MartinCostello.Logging.XUnit
         /// <summary>
         /// The padding to use for messages. This field is read-only.
         /// </summary>
-        private static readonly string MessagePadding = new string(' ', GetLogLevelString(LogLevel.Debug).Length + LogLevelPadding.Length);
+        private static readonly string MessagePadding = new(' ', GetLogLevelString(LogLevel.Debug).Length + LogLevelPadding.Length);
 
         /// <summary>
         /// The padding to use for new lines. This field is read-only.
@@ -202,9 +202,7 @@ namespace MartinCostello.Logging.XUnit
                     messageSink.OnMessage(sinkMessage);
                 }
             }
-#pragma warning disable CA1031
             catch (InvalidOperationException)
-#pragma warning restore CA1031
             {
                 // Ignore exception if the application tries to log after the test ends
                 // but before the ITestOutputHelper is detached, e.g. "There is no currently active test."
@@ -263,7 +261,7 @@ namespace MartinCostello.Logging.XUnit
             }
 
             var depth = 0;
-            static string DepthPadding(int depth) => new string(' ', depth * 2);
+            static string DepthPadding(int depth) => new(' ', depth * 2);
 
             while (stack.Count > 0)
             {

--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -27,17 +27,14 @@ namespace MartinCostello.Logging.XUnit
         /// <inheritdoc />
         public virtual ILogger CreateLogger(string categoryName)
         {
-            if (_outputHelperAccessor != null)
+            if (_outputHelperAccessor is not null)
             {
                 return new XUnitLogger(categoryName, _outputHelperAccessor, _options);
             }
-
-            if (_messageSinkAccessor != null)
+            else
             {
-                return new XUnitLogger(categoryName, _messageSinkAccessor, _options);
+                return new XUnitLogger(categoryName, _messageSinkAccessor!, _options);
             }
-
-            throw new InvalidOperationException("INTERNAL ERROR. This code path is not reachable since XUnitLoggerProvider is initialized with either a non null _outputHelperAccessor or a non null _messageSinkAccessor.");
         }
 
         /// <inheritdoc />

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -23,17 +23,17 @@ namespace MartinCostello.Logging.XUnit
             var accessor = Mock.Of<ITestOutputHelperAccessor>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit());
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(outputHelper));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(outputHelper, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as ITestOutputHelperAccessor) !));
-            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as ITestOutputHelperAccessor) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper) !));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>) !));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit());
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(outputHelper));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(outputHelper, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(accessor));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(accessor, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as ITestOutputHelperAccessor)!));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as ITestOutputHelperAccessor)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper)!));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>)!));
         }
 
         [Fact]
@@ -45,16 +45,16 @@ namespace MartinCostello.Logging.XUnit
             var accessor = Mock.Of<IMessageSinkAccessor>();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(messageSink));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(messageSink, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor));
-            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder) !.AddXUnit(accessor, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor) !));
-            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink) !));
-            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>) !));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(messageSink));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(messageSink, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(accessor));
+            Assert.Throws<ArgumentNullException>("builder", () => (null as ILoggingBuilder)!.AddXUnit(accessor, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor)!));
+            Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink)!));
+            Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>)!));
         }
 
         [Fact]
@@ -67,22 +67,22 @@ namespace MartinCostello.Logging.XUnit
             var options = new XUnitLoggerOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, options));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, ConfigureFunction));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, Filter));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(outputHelper, logLevel));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, ConfigureFunction));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, Filter));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, logLevel));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper) !, options));
-            Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(outputHelper, (null as XUnitLoggerOptions) !));
-            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Func<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(outputHelper, (null as Func<string, LogLevel, bool>) !));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper, options));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper, Filter));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(outputHelper, logLevel));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!, Filter));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!, logLevel));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => factory.AddXUnit((null as ITestOutputHelper)!, options));
+            Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(outputHelper, (null as XUnitLoggerOptions)!));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(outputHelper, (null as Func<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(outputHelper, (null as Func<string, LogLevel, bool>)!));
         }
 
         [Fact]
@@ -95,22 +95,22 @@ namespace MartinCostello.Logging.XUnit
             var options = new XUnitLoggerOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, options));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, ConfigureFunction));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, Filter));
-            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory) !.AddXUnit(messageSink, logLevel));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, ConfigureAction));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, ConfigureFunction));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, Filter));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, logLevel));
-            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink) !, options));
-            Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(messageSink, (null as XUnitLoggerOptions) !));
-            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Func<XUnitLoggerOptions>) !));
-            Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(messageSink, (null as Func<string, LogLevel, bool>) !));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink, options));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink, Filter));
+            Assert.Throws<ArgumentNullException>("factory", () => (null as ILoggerFactory)!.AddXUnit(messageSink, logLevel));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!, ConfigureAction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!, ConfigureFunction));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!, Filter));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!, logLevel));
+            Assert.Throws<ArgumentNullException>("messageSink", () => factory.AddXUnit((null as IMessageSink)!, options));
+            Assert.Throws<ArgumentNullException>("options", () => factory.AddXUnit(messageSink, (null as XUnitLoggerOptions)!));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("configure", () => factory.AddXUnit(messageSink, (null as Func<XUnitLoggerOptions>)!));
+            Assert.Throws<ArgumentNullException>("filter", () => factory.AddXUnit(messageSink, (null as Func<string, LogLevel, bool>)!));
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace MartinCostello.Logging.XUnit
         {
         }
 
-        private static XUnitLoggerOptions ConfigureFunction() => new XUnitLoggerOptions();
+        private static XUnitLoggerOptions ConfigureFunction() => new();
 
         private static bool Filter(string? categoryName, LogLevel level) => true;
     }

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -202,6 +202,53 @@ namespace MartinCostello.Logging.XUnit
             serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
         }
 
+        [Fact]
+        public static void AddXUnit_IMessageSink_With_LogLevel_Works()
+        {
+            // Arrange
+            ILoggerFactory factory = NullLoggerFactory.Instance;
+            var messageSink = Mock.Of<IMessageSink>();
+            var minLevel = LogLevel.Debug;
+
+            // Act
+            factory.AddXUnit(messageSink, minLevel);
+
+            // Assert
+            ILogger logger = factory.CreateLogger("SomeLogger");
+            logger.LogInformation("Some message");
+        }
+
+        [Fact]
+        public static void AddXUnit_IMessageSink_With_Filter_Works()
+        {
+            // Arrange
+            ILoggerFactory factory = NullLoggerFactory.Instance;
+            var messageSink = Mock.Of<IMessageSink>();
+
+            // Act
+            factory.AddXUnit(messageSink, (_) => { });
+
+            // Assert
+            ILogger logger = factory.CreateLogger("SomeLogger");
+            logger.LogInformation("Some message");
+        }
+
+        [Fact]
+        public static void AddXUnit_IMessageSink_With_Options_Works()
+        {
+            // Arrange
+            ILoggerFactory factory = NullLoggerFactory.Instance;
+            var messageSink = Mock.Of<IMessageSink>();
+            var options = new XUnitLoggerOptions();
+
+            // Act
+            factory.AddXUnit(messageSink, options);
+
+            // Assert
+            ILogger logger = factory.CreateLogger("SomeLogger");
+            logger.LogInformation("Some message");
+        }
+
         private static void ConfigureAction(XUnitLoggerOptions options)
         {
         }

--- a/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerProviderTests.cs
@@ -21,8 +21,8 @@ namespace MartinCostello.Logging.XUnit
             var options = new XUnitLoggerOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLoggerProvider((null as ITestOutputHelper) !, options));
-            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLoggerProvider((null as ITestOutputHelperAccessor) !, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLoggerProvider((null as ITestOutputHelper)!, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLoggerProvider((null as ITestOutputHelperAccessor)!, options));
             Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(outputHelper, null!));
             Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(accessor, null!));
         }
@@ -36,8 +36,8 @@ namespace MartinCostello.Logging.XUnit
             var options = new XUnitLoggerOptions();
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>("messageSink", () => new XUnitLoggerProvider((null as IMessageSink) !, options));
-            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLoggerProvider((null as IMessageSinkAccessor) !, options));
+            Assert.Throws<ArgumentNullException>("messageSink", () => new XUnitLoggerProvider((null as IMessageSink)!, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLoggerProvider((null as IMessageSinkAccessor)!, options));
             Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(messageSink, null!));
             Assert.Throws<ArgumentNullException>("options", () => new XUnitLoggerProvider(accessor, null!));
         }
@@ -58,7 +58,7 @@ namespace MartinCostello.Logging.XUnit
             {
                 Constructor.ITestOutputHelper => new XUnitLoggerProvider(testOutputHelper, options),
                 Constructor.IMessageSink => new XUnitLoggerProvider(messageSink, options),
-                _ => throw new ArgumentOutOfRangeException(nameof(constructor), constructor, null)
+                _ => throw new ArgumentOutOfRangeException(nameof(constructor), constructor, null),
             };
 
             // Act

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -38,6 +38,16 @@ namespace MartinCostello.Logging.XUnit
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("value", () => logger.Filter = null!);
+            Assert.Throws<ArgumentNullException>("value", () => logger.MessageSinkMessageFactory = null!);
+
+            // Arrange
+            Func<string?, LogLevel, bool> filter = (_, _) => true;
+
+            // Act
+            logger.Filter = filter;
+
+            // Assert
+            logger.Filter.ShouldBeSameAs(filter);
         }
 
         [Theory]

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -28,10 +28,10 @@ namespace MartinCostello.Logging.XUnit
 
             // Act and Assert
             Assert.Throws<ArgumentNullException>("name", () => new XUnitLogger(null!, outputHelper, options));
-            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLogger(name, (null as ITestOutputHelper) !, options));
-            Assert.Throws<ArgumentNullException>("messageSink", () => new XUnitLogger(name, (null as IMessageSink) !, options));
-            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLogger(name, (null as ITestOutputHelperAccessor) !, options));
-            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLogger(name, (null as IMessageSinkAccessor) !, options));
+            Assert.Throws<ArgumentNullException>("outputHelper", () => new XUnitLogger(name, (null as ITestOutputHelper)!, options));
+            Assert.Throws<ArgumentNullException>("messageSink", () => new XUnitLogger(name, (null as IMessageSink)!, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLogger(name, (null as ITestOutputHelperAccessor)!, options));
+            Assert.Throws<ArgumentNullException>("accessor", () => new XUnitLogger(name, (null as IMessageSinkAccessor)!, options));
 
             // Arrange
             var logger = new XUnitLogger(name, outputHelper, options);
@@ -72,7 +72,7 @@ namespace MartinCostello.Logging.XUnit
                 {
                     Constructor.ITestOutputHelper => new XUnitLogger(name, testOutputHelper, opts),
                     Constructor.IMessageSink => new XUnitLogger(name, messageSink, opts),
-                    _ => throw new ArgumentOutOfRangeException(nameof(constructor), constructor, null)
+                    _ => throw new ArgumentOutOfRangeException(nameof(constructor), constructor, null),
                 };
             }
 
@@ -682,7 +682,7 @@ namespace MartinCostello.Logging.XUnit
             mock.Verify((p) => p.WriteLine(expected), Times.Once());
         }
 
-        private static DateTimeOffset StaticClock() => new DateTimeOffset(2018, 08, 19, 17, 12, 16, TimeSpan.FromHours(1));
+        private static DateTimeOffset StaticClock() => new(2018, 08, 19, 17, 12, 16, TimeSpan.FromHours(1));
 
         private static IMessageSinkMessage DiagnosticMessageFactory(string message) => new DiagnosticMessage(message);
 
@@ -698,7 +698,7 @@ namespace MartinCostello.Logging.XUnit
 
         private static string FormatterEmpty<TState>(TState? state, Exception? exception) => string.Empty;
 
-        private static string FormatterLong<TState>(TState? state, Exception? exception) => new string('a', 2048);
+        private static string FormatterLong<TState>(TState? state, Exception? exception) => new('a', 2048);
 
         private static string FormatterNull<TState>(TState? state, Exception? exception) => null!;
     }


### PR DESCRIPTION
* Cover some more lines to verify they don't throw any exceptions.
* Assert not null to remove need for unreachable code to keep the compiler happy.
* Update StyleCop.Analyzers to the latest version.
* Bump version to 0.2.0 instead of 0.1.3.
