### PR TITLE
Ignore xunit.extensibility.execution updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,7 @@ updates:
     - "> 2.0.0"
   - dependency-name: xunit.abstractions
     versions:
-    - "> 2.0.1, < 2.1"
+    - "> 2.0.1"
+  - dependency-name: xunit.extensibility.execution
+    versions:
+    - "> 2.4.1"


### PR DESCRIPTION
Ignore dependabot updates for `xunit.extensibility.execution`.
