### PR TITLE
Added ProviderAliasAttribute to add standard configuration support.

### DIFF
--- a/src/Logging.XUnit/XUnitLoggerProvider.cs
+++ b/src/Logging.XUnit/XUnitLoggerProvider.cs
@@ -8,6 +8,7 @@ namespace MartinCostello.Logging.XUnit;
 /// <summary>
 /// A class representing an <see cref="ILoggerProvider"/> to use with xunit.
 /// </summary>
+[ProviderAlias("XUnit")]
 public partial class XUnitLoggerProvider : ILoggerProvider
 {
     /// <summary>


### PR DESCRIPTION
This fix allows to configure severity levels and others through the appSettings.

```Json
{
  "Logging": {
    "XUnit": {
      "LogLevel": {
        "Default": "Trace",
        "Microsoft.AspNetCore.Mvc.*": "Warning",
        "Microsoft.AspNetCore.*": "Information",
        "Microsoft.EntityFrameworkCore.*": "Warning"
      }
    }
  }
}
```