### PR TITLE
Remove redundant suppressions

### DIFF
--- a/tests/SampleApp/Program.cs
+++ b/tests/SampleApp/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 var builder = WebApplication.CreateBuilder(args);
 
 var app = builder.Build();


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
