### PR TITLE
Validate Authenticode signatures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,15 +133,22 @@ jobs:
             if ($authlintProcess.ExitCode -ne 0) {
               Write-Output "::warning::$dll in NuGet package $package failed signature validation."
               $invalidDlls++
+            } else {
+              Write-Output "$dll in NuGet package $package has a valid signature."
             }
           }
 
           if ($invalidDlls -gt 0) {
             $invalidPackages++
+          } else {
+            Write-Output "All $($dlls.Length) DLLs in NuGet package $package have valid signatures."
           }
         }
         if ($invalidPackages -gt 0) {
           Write-Output "::error::$invalidPackages NuGet package(s) failed signature validation."
+          throw "One or more NuGet packages failed signature validation."
+        } else {
+          Write-Output "All $($packages.Length) NuGet packages have valid signatures."
         }
 
   publish-myget:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         $artifacts = Join-Path $authlintSource "artifacts"
         $authlint = Join-Path $artifacts "authlint.exe"
 
-        dotnet publish $authLintProject --configuration Release --output $artifacts --runtime win-x64 --self-contained false
+        dotnet publish $authLintProject --configuration Release --output $artifacts --runtime win-x64 --self-contained false /p:NoWarn=CS8604
 
         if ($LASTEXITCODE -ne 0) {
           throw "Failed to publish AuthenticodeLint."
@@ -128,6 +128,7 @@ jobs:
           $invalidDlls = 0
           foreach ($dll in $dlls) {
             & $authlint "-in" $dll "-verbose"
+            Write-Output "authlint exited with $LASTEXITCODE"
             if ($LASTEXITCODE -ne 0) {
               Write-Output "::warning::$dll in NuGet package $package failed signature validation."
               $invalidDlls++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
           $invalidDlls = 0
           foreach ($dll in $dlls) {
-            $authlint "-in" $dll "-verbose"
+            & $authlint "-in" $dll "-verbose"
             if ($LASTEXITCODE -ne 0) {
               Write-Output "::warning::$dll in NuGet package $package failed signature validation."
               $invalidDlls++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
 
   validate-packages:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
 
     - name: Download packages
@@ -93,6 +93,53 @@ jobs:
         }
         if ($invalidPackages -gt 0) {
           Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
+        }
+
+    - name: Checkout vcsjones/AuthenticodeLint
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      with:
+        path: AuthenticodeLint
+        ref: ccfaec53ee5c1b14f029cb8156e0653c530f8b65
+        repository: vcsjones/AuthenticodeLint
+
+    - name: Build AuthenticodeLint and validate NuGet package contents
+      shell: pwsh
+      run: |
+        $authlintSource = Join-Path "." "AuthenticodeLint"
+        $authLintProject = Join-Path $authlintSource "AuthenticodeLint.csproj"
+        $artifacts = Join-Path $authlintSource "artifacts"
+        $authlint = Join-Path $artifacts "authlint.exe"
+
+        dotnet publish $authLintProject --configuration Release --output $artifacts --runtime win-x64 --self-contained false
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to publish AuthenticodeLint."
+        }
+
+        $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
+        $invalidPackages = 0
+        foreach ($package in $packages) {
+          $packageName = Split-Path $package -Leaf
+          $extractedNupkg = Join-Path "." "extracted" $packageName
+          Expand-Archive -Path $package -DestinationPath $extractedNupkg -Force
+
+          $dlls = Get-ChildItem -Path $extractedNupkg -Filter "*.dll" -Recurse | ForEach-Object { $_.FullName }
+
+          $invalidDlls = 0
+          foreach ($dll in $dlls) {
+            $authlint -in $dll -verbose
+            if ($LASTEXITCODE -ne 0) {
+              Write-Output "::warning::$dll in NuGet package $package failed signature validation."
+              $invalidDlls++
+            }
+          }
+
+          if ($invalidDlls -gt 0) {
+            $invalidPackages++
+          }
+        }
+        if ($invalidPackages -gt 0) {
+          Write-Output "::error::$invalidPackages NuGet package(s) failed signature validation."
         }
 
   publish-myget:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
           $invalidDlls = 0
           foreach ($dll in $dlls) {
-            $authlint -in $dll -verbose
+            $authlint "-in" $dll "-verbose"
             if ($LASTEXITCODE -ne 0) {
               Write-Output "::warning::$dll in NuGet package $package failed signature validation."
               $invalidDlls++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       shell: pwsh
       run: |
         $authlintSource = Join-Path "." "AuthenticodeLint"
-        $authLintProject = Join-Path $authlintSource "AuthenticodeLint.csproj"
+        $authLintProject = Join-Path $authlintSource "AuthenticodeLint" "AuthenticodeLint.csproj"
         $artifacts = Join-Path $authlintSource "artifacts"
         $authlint = Join-Path $artifacts "authlint.exe"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,9 +127,10 @@ jobs:
 
           $invalidDlls = 0
           foreach ($dll in $dlls) {
-            & $authlint "-in" $dll "-verbose"
-            Write-Output "authlint exited with $LASTEXITCODE"
-            if ($LASTEXITCODE -ne 0) {
+            $authlintProcess = Start-Process -FilePath $authlint -ArgumentList @("-in", $dll, "-verbose") -PassThru
+            $authlintProcess.WaitForExit()
+
+            if ($authlintProcess.ExitCode -ne 0) {
               Write-Output "::warning::$dll in NuGet package $package failed signature validation."
               $invalidDlls++
             }


### PR DESCRIPTION
Throwaway change to validate building vcsjones/AuthenticodeLint from source to determine whether NuGet packages contain Authenticode-signed files.

As I don't have a personal Authenticode certificate, this build should fail due to the DLL having no signature.