### PR TITLE
Remove MyGet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,27 +95,6 @@ jobs:
           Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
         }
 
-  publish-myget:
-    needs: validate-packages
-    runs-on: ubuntu-latest
-    if: false
-    #if: |
-    #  github.event.repository.fork == false &&
-    #  (github.ref_name == github.event.repository.default_branch ||
-    #   startsWith(github.ref, 'refs/tags/v'))
-    steps:
-
-    - name: Download packages
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      with:
-        name: packages-windows
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
-
-    - name: Push NuGet packages to MyGet
-      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.MYGET_TOKEN }} --skip-duplicate --source https://www.myget.org/F/martincostello/api/v2/package
-
   publish-nuget:
     needs: validate-packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove publishing of prerelease packages to MyGet.

Being down for over 24 hours with zero communication has completely tarnished their reputation with me, so even if it comes back online I'm not going to use it further.
