### PR TITLE
Use env var for actionlint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,9 @@ jobs:
 
     - name: Lint workflows
       shell: bash
+      env:
+        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"
-        bash <(curl --silent --show-error "https://raw.githubusercontent.com/rhysd/actionlint/7b75d16d41920ec126e6f3269db0c6f3ab613c38/scripts/download-actionlint.bash")
+        bash <(curl --silent --show-error "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
         ./actionlint -color


### PR DESCRIPTION
Reverts martincostello/xunit-logging#464 as ossf/scorecard still flags it.
