### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Logging.XUnit.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Logging.XUnit.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/xunit-logging</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>


### PR DESCRIPTION
Fix `BA2004` warning from Binskim.
