### PR TITLE
Add net8.0 target

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 To contribute changes (source code, scripts, configuration) to this repository please follow the steps below. These steps are a guideline for contributing and do not necessarily need to be followed for all changes.
 
 1. If you intend to fix a bug please create an issue before forking the repository.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a bug report to help us improve the library
 labels: bug
-
 ---
 
 ### Describe the bug
@@ -32,11 +31,11 @@ A clear and concise description of what actually happened. If an exception occur
 ### System information
 
 <!--
- - OS: [e.g. Windows 10]
- - Library Version [e.g. 0.2.1]
+ - OS: [e.g. Windows 11]
+ - Library Version [e.g. 0.4.0]
  - xunit version [e.g. 2.4.0]
  - .NET version (e.g. output from `dotnet --info`)
- - IDE and version [e.g. Visual Studio 17.2.0]
+ - IDE and version [e.g. Visual Studio 17.8.0]
 -->
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Contact me
+    url: https://twitter.com/martin_costello
+    about: You can also contact me on Twitter.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for a feature of this library
 labels: feature-request
-
 ---
 
 ### Is your feature request related to a problem? Please describe.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,8 +44,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/Logging.XUnit.sln
+++ b/Logging.XUnit.sln
@@ -28,10 +28,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{278BCCB1
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{D0426D09-1FF8-4E1F-A9AF-38DDEE5D7CCA}"
 	ProjectSection(SolutionItems) = preProject
+		.github\actionlint-matcher.json = .github\actionlint-matcher.json
+		.github\CODEOWNERS = .github\CODEOWNERS
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\dependabot.yml = .github\dependabot.yml
+		.github\FUNDING.yml = .github\FUNDING.yml
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
-		.github\stale.yml = .github\stale.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{701E574A-6366-4AF9-9319-237968FA1089}"
@@ -43,6 +46,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{F37263E7-6656-4A2B-B02E-538B5F9970BD}"
 	ProjectSection(SolutionItems) = preProject
 		.github\ISSUE_TEMPLATE\bug_report.md = .github\ISSUE_TEMPLATE\bug_report.md
+		.github\ISSUE_TEMPLATE\config.yml = .github\ISSUE_TEMPLATE\config.yml
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
@@ -55,7 +59,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{7764A046-DEE7-4D88-83E2-537DB7767123}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
-		.github\workflows\update-dotnet-sdk.yml = .github\workflows\update-dotnet-sdk.yml
+		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
+		.github\workflows\dependency-review.yml = .github\workflows\dependency-review.yml
+		.github\workflows\lint.yml = .github\workflows\lint.yml
+		.github\workflows\ossf-scorecard.yml = .github\workflows\ossf-scorecard.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/Logging.XUnit/IMessageSinkExtensions.cs
+++ b/src/Logging.XUnit/IMessageSinkExtensions.cs
@@ -24,10 +24,14 @@ public static class IMessageSinkExtensions
     /// </exception>
     public static ILoggerFactory ToLoggerFactory(this IMessageSink messageSink)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(messageSink);
+#else
         if (messageSink == null)
         {
             throw new ArgumentNullException(nameof(messageSink));
         }
+#endif
 
         return new LoggerFactory().AddXUnit(messageSink);
     }

--- a/src/Logging.XUnit/ITestOutputHelperExtensions.cs
+++ b/src/Logging.XUnit/ITestOutputHelperExtensions.cs
@@ -24,10 +24,14 @@ public static class ITestOutputHelperExtensions
     /// </exception>
     public static ILoggerFactory ToLoggerFactory(this ITestOutputHelper outputHelper)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(outputHelper);
+#else
         if (outputHelper == null)
         {
             throw new ArgumentNullException(nameof(outputHelper));
         }
+#endif
 
         return new LoggerFactory().AddXUnit(outputHelper);
     }

--- a/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
+++ b/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
@@ -7,19 +7,26 @@
     <NoWarn>$(NoWarn)</NoWarn>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.Logging.XUnit</PackageId>
-    <PackageValidationBaselineVersion>0.2.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.3.0</PackageValidationBaselineVersion>
     <RootNamespace>MartinCostello.Logging.XUnit</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Title>xunit Logging Extensions</Title>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugSymbols>True</DebugSymbols>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="xunit.extensibility.execution" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Update="Microsoft.Extensions.Logging" VersionOverride="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.InteropServices.GuidAttribute">

--- a/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
+++ b/src/Logging.XUnit/MartinCostello.Logging.XUnit.csproj
@@ -4,7 +4,6 @@
     <Description>Extensions for Microsoft.Extensions.Logging for xunit.</Description>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn)</NoWarn>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.Logging.XUnit</PackageId>
     <PackageValidationBaselineVersion>0.3.0</PackageValidationBaselineVersion>

--- a/src/Logging.XUnit/XUnitLogScope.cs
+++ b/src/Logging.XUnit/XUnitLogScope.cs
@@ -37,7 +37,7 @@ internal sealed class XUnitLogScope(object state)
     internal XUnitLogScope? Parent { get; private set; }
 
     /// <inheritdoc />
-    public override string ToString()
+    public override string? ToString()
         => State.ToString();
 
     /// <summary>

--- a/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.IMessageSink.cs
@@ -25,6 +25,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSinkAccessor accessor)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(accessor);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -34,6 +38,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(accessor));
         }
+#endif
 
         return builder.AddXUnit(accessor, static (_) => { });
     }
@@ -52,6 +57,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSinkAccessor accessor, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(accessor);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -66,12 +76,15 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = new XUnitLoggerOptions();
 
         configure(options);
 
+#pragma warning disable CA2000
         builder.AddProvider(new XUnitLoggerProvider(accessor, options));
+#pragma warning restore CA2000
 
         builder.Services.TryAddSingleton(accessor);
 
@@ -91,6 +104,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink messageSink)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(messageSink);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -100,6 +117,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(messageSink));
         }
+#endif
 
         return builder.AddXUnit(messageSink, static (_) => { });
     }
@@ -118,6 +136,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(messageSink);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -132,12 +155,15 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = new XUnitLoggerOptions();
 
         configure(options);
 
+#pragma warning disable CA2000
         return builder.AddProvider(new XUnitLoggerProvider(messageSink, options));
+#pragma warning restore CA2000
     }
 
     /// <summary>
@@ -154,6 +180,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, LogLevel minLevel)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -163,6 +193,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(messageSink));
         }
+#endif
 
         return factory.AddXUnit(messageSink, (_, level) => level >= minLevel);
     }
@@ -181,6 +212,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Func<string?, LogLevel, bool> filter)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+        ArgumentNullException.ThrowIfNull(filter);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -195,6 +231,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(filter));
         }
+#endif
 
         return factory.AddXUnit(messageSink, (options) => options.Filter = filter);
     }
@@ -212,6 +249,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -221,6 +262,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(messageSink));
         }
+#endif
 
         return factory.AddXUnit(messageSink, static (_) => { });
     }
@@ -239,6 +281,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, XUnitLoggerOptions options)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+        ArgumentNullException.ThrowIfNull(options);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -253,6 +300,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(options));
         }
+#endif
 
         return factory.AddXUnit(messageSink, () => options);
     }
@@ -271,6 +319,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -285,15 +338,14 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
-        return factory.AddXUnit(
-            messageSink,
-            () =>
-            {
-                var options = new XUnitLoggerOptions();
-                configure(options);
-                return options;
-            });
+        return factory.AddXUnit(messageSink, () =>
+        {
+            var options = new XUnitLoggerOptions();
+            configure(options);
+            return options;
+        });
     }
 
     /// <summary>
@@ -310,6 +362,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, IMessageSink messageSink, Func<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(messageSink);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -324,10 +381,13 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = configure();
 
+#pragma warning disable CA2000
         factory.AddProvider(new XUnitLoggerProvider(messageSink, options));
+#pragma warning restore CA2000
 
         return factory;
     }

--- a/src/Logging.XUnit/XUnitLoggerExtensions.ITestOutputHelper.cs
+++ b/src/Logging.XUnit/XUnitLoggerExtensions.ITestOutputHelper.cs
@@ -26,10 +26,14 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
+#endif
 
         return builder.AddXUnit(new AmbientTestOutputHelperAccessor(), static (_) => { });
     }
@@ -47,6 +51,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelperAccessor accessor)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(accessor);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -56,6 +64,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(accessor));
         }
+#endif
 
         return builder.AddXUnit(accessor, static (_) => { });
     }
@@ -74,6 +83,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelperAccessor accessor, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(accessor);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -88,12 +102,15 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = new XUnitLoggerOptions();
 
         configure(options);
 
+#pragma warning disable CA2000
         builder.AddProvider(new XUnitLoggerProvider(accessor, options));
+#pragma warning restore CA2000
 
         builder.Services.TryAddSingleton(accessor);
 
@@ -113,6 +130,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelper outputHelper)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -122,6 +143,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(outputHelper));
         }
+#endif
 
         return builder.AddXUnit(outputHelper, static (_) => { });
     }
@@ -140,6 +162,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder, ITestOutputHelper outputHelper, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -154,12 +181,15 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = new XUnitLoggerOptions();
 
         configure(options);
 
+#pragma warning disable CA2000
         return builder.AddProvider(new XUnitLoggerProvider(outputHelper, options));
+#pragma warning restore CA2000
     }
 
     /// <summary>
@@ -176,6 +206,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper, LogLevel minLevel)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -185,6 +219,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(outputHelper));
         }
+#endif
 
         return factory.AddXUnit(outputHelper, (_, level) => level >= minLevel);
     }
@@ -203,6 +238,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper, Func<string?, LogLevel, bool> filter)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+        ArgumentNullException.ThrowIfNull(filter);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -217,6 +257,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(filter));
         }
+#endif
 
         return factory.AddXUnit(outputHelper, (options) => options.Filter = filter);
     }
@@ -234,6 +275,10 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -243,6 +288,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(outputHelper));
         }
+#endif
 
         return factory.AddXUnit(outputHelper, static (_) => { });
     }
@@ -261,6 +307,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper, XUnitLoggerOptions options)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+        ArgumentNullException.ThrowIfNull(options);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -275,6 +326,7 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(options));
         }
+#endif
 
         return factory.AddXUnit(outputHelper, () => options);
     }
@@ -293,6 +345,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper, Action<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -307,15 +364,14 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
-        return factory.AddXUnit(
-            outputHelper,
-            () =>
-            {
-                var options = new XUnitLoggerOptions();
-                configure(options);
-                return options;
-            });
+        return factory.AddXUnit(outputHelper, () =>
+        {
+            var options = new XUnitLoggerOptions();
+            configure(options);
+            return options;
+        });
     }
 
     /// <summary>
@@ -332,6 +388,11 @@ public static partial class XUnitLoggerExtensions
     /// </exception>
     public static ILoggerFactory AddXUnit(this ILoggerFactory factory, ITestOutputHelper outputHelper, Func<XUnitLoggerOptions> configure)
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(outputHelper);
+        ArgumentNullException.ThrowIfNull(configure);
+#else
         if (factory == null)
         {
             throw new ArgumentNullException(nameof(factory));
@@ -346,10 +407,13 @@ public static partial class XUnitLoggerExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
+#endif
 
         var options = configure();
 
+#pragma warning disable CA2000
         factory.AddProvider(new XUnitLoggerProvider(outputHelper, options));
+#pragma warning restore CA2000
 
         return factory;
     }

--- a/tests/Logging.XUnit.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Logging.XUnit.Tests/Integration/HttpServerFixture.cs
@@ -4,14 +4,13 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Logging;
-using SampleApp;
 
 namespace MartinCostello.Logging.XUnit.Integration;
 
 /// <summary>
 /// A test fixture representing an HTTP server hosting the sample application. This class cannot be inherited.
 /// </summary>
-public sealed class HttpServerFixture : WebApplicationFactory<FakeEntrypoint>, ITestOutputHelperAccessor
+public sealed class HttpServerFixture : WebApplicationFactory<SampleApp.Program>, ITestOutputHelperAccessor
 {
     /// <inheritdoc />
     public ITestOutputHelper? OutputHelper { get; set; }

--- a/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
+++ b/tests/Logging.XUnit.Tests/MartinCostello.Logging.XUnit.Tests.csproj
@@ -7,7 +7,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Logging.XUnit</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -102,7 +102,7 @@ public static class XUnitLoggerTests
         var logger = new XUnitLogger(name, outputHelper, options);
 
         // Act
-        using IDisposable actual = logger.BeginScope(true);
+        using var actual = logger.BeginScope(true);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -116,9 +116,10 @@ public static class XUnitLoggerTests
         var outputHelper = Substitute.For<ITestOutputHelper>();
         var options = new XUnitLoggerOptions();
         var logger = new XUnitLogger(name, outputHelper, options);
+        string state = null!;
 
         // Act
-        Assert.Throws<ArgumentNullException>("state", () => logger.BeginScope(null as string));
+        Assert.Throws<ArgumentNullException>("state", () => logger.BeginScope(state));
     }
 
     [Theory]
@@ -319,7 +320,7 @@ public static class XUnitLoggerTests
             new[] { "[2018-08-19 16:12:16Z] warn: MyName[3]", "      Message|False|True", "System.InvalidOperationException: Invalid" });
 
         // Act
-        logger.Log<string>(LogLevel.Warning, new EventId(3), null, exception, Formatter);
+        logger.Log<string?>(LogLevel.Warning, new EventId(3), null, exception, Formatter);
 
         // Assert
         outputHelper.Received(1).WriteLine(expected);
@@ -347,7 +348,7 @@ public static class XUnitLoggerTests
             new[] { "[2018-08-19 16:12:16Z] fail: MyName[4]", "      Message|False|False" });
 
         // Act
-        logger.Log<string>(LogLevel.Error, new EventId(4), null, null, Formatter);
+        logger.Log<string?>(LogLevel.Error, new EventId(4), null, null, Formatter);
 
         // Assert
         outputHelper.Received(1).WriteLine(expected);
@@ -431,7 +432,7 @@ public static class XUnitLoggerTests
             new[] { "[2018-08-19 16:12:16Z] info: MyName[0]", "      Message|False|False" });
 
         // Act
-        logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+        logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
 
         // Assert
         outputHelper.Received(1).WriteLine(expected);
@@ -475,7 +476,7 @@ public static class XUnitLoggerTests
                     using (logger.BeginScope(null!))
 #pragma warning restore CA2254
                     {
-                        logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+                        logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
                     }
                 }
             }
@@ -515,7 +516,7 @@ public static class XUnitLoggerTests
             new KeyValuePair<string, object>("ScopeKey", "ScopeValue"),
         }))
         {
-            logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+            logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
         }
 
         // Assert
@@ -556,7 +557,7 @@ public static class XUnitLoggerTests
             new KeyValuePair<string, object>("ScopeKeyThree", "ScopeValueThree"),
         }))
         {
-            logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+            logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
         }
 
         // Assert
@@ -607,7 +608,7 @@ public static class XUnitLoggerTests
                 new KeyValuePair<string, object>("ScopeKeySix", "ScopeValueSix"),
             }))
             {
-                logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+                logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
             }
         }
 
@@ -644,7 +645,7 @@ public static class XUnitLoggerTests
         // Act
         using (logger.BeginScope(new[] { "ScopeKeyOne", "ScopeKeyTwo", "ScopeKeyThree" }))
         {
-            logger.Log<string>(LogLevel.Information, 0, null, null, Formatter);
+            logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);
         }
 
         // Assert

--- a/tests/Logging.XUnit.Tests/xunit.runner.json
+++ b/tests/Logging.XUnit.Tests/xunit.runner.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "diagnosticMessages": true,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "replaceUnderscoreWithSpace"
+  "methodDisplay": "method"
 }

--- a/tests/SampleApp/FakeEntrypoint.cs
+++ b/tests/SampleApp/FakeEntrypoint.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
-// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
-
-namespace SampleApp;
-
-public class FakeEntrypoint
-{
-}

--- a/tests/SampleApp/Program.cs
+++ b/tests/SampleApp/Program.cs
@@ -16,3 +16,11 @@ app.MapPut("/api/values/{id}", (string id) => Results.NoContent());
 app.MapDelete("/api/values/{id}", (string id) => Results.NoContent());
 
 app.Run();
+
+namespace SampleApp
+{
+    public partial class Program
+    {
+        // Expose the Program class for use with WebApplicationFactory<T>
+    }
+}

--- a/tests/SampleApp/SampleApp.csproj
+++ b/tests/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1801;CA1822;CA1861;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1801;CA1822;CA1861;SA1600;SA1601</NoWarn>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Add target for `net8.0`.
- Fix new code analysis warnings.
- Mark `net8.0` as AoT compatible.
- Bump version to 0.4.0.
- Update package baseline.
- Remove redundant MSBuild properties.
- Remove `methodDisplayOptions` override.
- Remove `FakeEntrypoint` and just expose the `Program` class.
- Add contact details.
- Tidy up formatting if `.github` templates.
- Update solution items.
