### PR TITLE
Solution improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,17 @@ charset = utf-8-bom
 # .NET Coding Conventions     #
 ###############################
 [*.{cs,vb}]
+
+# Enable style analyzers
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+dotnet_diagnostic.IDE0005.severity = silent
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_diagnostic.IDE0058.severity = silent
+dotnet_diagnostic.IDE0072.severity = silent
+dotnet_diagnostic.IDE0079.severity = silent
+
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -81,6 +92,7 @@ csharp_style_expression_bodied_operators = false:none
 csharp_style_expression_bodied_properties = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_local_functions = when_on_single_line
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Logging.XUnit.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
@@ -19,6 +19,7 @@
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -26,7 +27,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);CA1848</NoWarn>
-    <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -50,6 +50,10 @@
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA0001;SA1602</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageIcon)' != '' ">
     <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Pack="True" PackagePath="" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,9 @@
 <Project>
   <ItemGroup>
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.3" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
@@ -8,18 +12,14 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="ReportGenerator" Version="5.2.4" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" NoWarn="RT0003" />
     <PackageReference Include="ReportGenerator" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerExtensionsTests.cs
@@ -28,8 +28,8 @@ public static class XUnitLoggerExtensionsTests
         Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as ITestOutputHelperAccessor)!, ConfigureAction));
         Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper)!));
         Assert.Throws<ArgumentNullException>("outputHelper", () => builder.AddXUnit((null as ITestOutputHelper)!, ConfigureAction));
-        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, (null as Action<XUnitLoggerOptions>)!));
-        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>)!));
+        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(outputHelper, null!));
+        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, null!));
     }
 
     [Fact]
@@ -49,8 +49,8 @@ public static class XUnitLoggerExtensionsTests
         Assert.Throws<ArgumentNullException>("accessor", () => builder.AddXUnit((null as IMessageSinkAccessor)!, ConfigureAction));
         Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink)!));
         Assert.Throws<ArgumentNullException>("messageSink", () => builder.AddXUnit((null as IMessageSink)!, ConfigureAction));
-        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(messageSink, (null as Action<XUnitLoggerOptions>)!));
-        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, (null as Action<XUnitLoggerOptions>)!));
+        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(messageSink, null!));
+        Assert.Throws<ArgumentNullException>("configure", () => builder.AddXUnit(accessor, null!));
     }
 
     [Fact]

--- a/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
+++ b/tests/Logging.XUnit.Tests/XUnitLoggerTests.cs
@@ -287,7 +287,7 @@ public static class XUnitLoggerTests
 
         string expected = string.Join(
             Environment.NewLine,
-            new[] { "[2018-08-19 16:12:16Z] info: MyName[2]", "System.InvalidOperationException: Invalid" });
+            ["[2018-08-19 16:12:16Z] info: MyName[2]", "System.InvalidOperationException: Invalid"]);
 
         // Act
         logger.Log(LogLevel.Information, new EventId(2), "state", exception, FormatterNull);
@@ -317,7 +317,7 @@ public static class XUnitLoggerTests
 
         string expected = string.Join(
             Environment.NewLine,
-            new[] { "[2018-08-19 16:12:16Z] warn: MyName[3]", "      Message|False|True", "System.InvalidOperationException: Invalid" });
+            ["[2018-08-19 16:12:16Z] warn: MyName[3]", "      Message|False|True", "System.InvalidOperationException: Invalid"]);
 
         // Act
         logger.Log<string?>(LogLevel.Warning, new EventId(3), null, exception, Formatter);
@@ -345,7 +345,7 @@ public static class XUnitLoggerTests
 
         string expected = string.Join(
             Environment.NewLine,
-            new[] { "[2018-08-19 16:12:16Z] fail: MyName[4]", "      Message|False|False" });
+            ["[2018-08-19 16:12:16Z] fail: MyName[4]", "      Message|False|False"]);
 
         // Act
         logger.Log<string?>(LogLevel.Error, new EventId(4), null, null, Formatter);
@@ -379,7 +379,7 @@ public static class XUnitLoggerTests
 
         string expected = string.Join(
             Environment.NewLine,
-            new[] { $"[2018-08-19 16:12:16Z] {shortLevel}: Your Name[85]", "      Message|True|False" });
+            [$"[2018-08-19 16:12:16Z] {shortLevel}: Your Name[85]", "      Message|True|False"]);
 
         // Act
         logger.Log(logLevel, new EventId(85), "Martin", null, Formatter);
@@ -429,7 +429,7 @@ public static class XUnitLoggerTests
 
         string expected = string.Join(
             Environment.NewLine,
-            new[] { "[2018-08-19 16:12:16Z] info: MyName[0]", "      Message|False|False" });
+            ["[2018-08-19 16:12:16Z] info: MyName[0]", "      Message|False|False"]);
 
         // Act
         logger.Log<string?>(LogLevel.Information, 0, null, null, Formatter);


### PR DESCRIPTION
- Enable (almost) all built-in style analyzers.
- Fix new style warnings.
- Use global package references.
- Add reference trimmer analyzer.
