### PR TITLE
Ignore CA1515

### DIFF
--- a/Logging.XUnit.ruleset
+++ b/Logging.XUnit.ruleset
@@ -3,6 +3,7 @@
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1515" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />


### PR DESCRIPTION
Ignore the CA1515 analyser rule added for .NET 9.
