### PR TITLE
Downgrade xunit.extensibility.execution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.9.2" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="xunit.v3" Version="1.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.0" />


### PR DESCRIPTION
Downgrade xunit.extensibility.execution to 2.4.1 as it was accidentally upgraded as part of 0.5.0 and the change is causing issues for some projects.
