### PR TITLE
Revert xunit.extensibility.execution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="xunit.v3" Version="1.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.0" />


### PR DESCRIPTION
Revert unwanted update to xunit.extensibility.execution from #818 as otherwise it causes issues for consumers (see #809).
