### PR TITLE
Use TestContext.Current for output helper

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <PackageTags>xunit;logging</PackageTags>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseDefaultAssemblyOriginatorKeyFile>true</UseDefaultAssemblyOriginatorKeyFile>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
-    <VersionPrefix>0.5.2</VersionPrefix>
+    <AssemblyVersion>0.6.0.0</AssemblyVersion>
+    <PackageValidationBaselineVersion>0.5.1</PackageValidationBaselineVersion>
+    <VersionPrefix>0.6.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Logging.XUnit.v3/CompositeTestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit.v3/CompositeTestOutputHelperAccessor.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Logging.XUnit;
+
+/// <summary>
+/// A class representing an implementation of <see cref="ITestOutputHelperAccessor"/> that
+/// uses <see cref="AmbientTestOutputHelperAccessor"/> with <see cref="TestContextTestOutputHelperAccessor"/>
+/// as a fallback. This class cannot be inherited.
+/// </summary>
+internal sealed class CompositeTestOutputHelperAccessor : ITestOutputHelperAccessor
+{
+    /// <summary>
+    /// The singleton instance of <see cref="CompositeTestOutputHelperAccessor"/>. This field is read-only.
+    /// </summary>
+    internal static readonly CompositeTestOutputHelperAccessor Instance = new();
+
+    /// <summary>
+    /// Gets or sets the current <see cref="ITestOutputHelper"/>.
+    /// </summary>
+    public ITestOutputHelper? OutputHelper
+    {
+        get => AmbientTestOutputHelperAccessor.Instance.OutputHelper ?? TestContextTestOutputHelperAccessor.Instance.OutputHelper;
+        set => AmbientTestOutputHelperAccessor.Instance.OutputHelper = value;
+    }
+}

--- a/src/Logging.XUnit.v3/ITestOutputHelperAccessorExtensions.cs
+++ b/src/Logging.XUnit.v3/ITestOutputHelperAccessorExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace MartinCostello.Logging.XUnit;
+
+/// <summary>
+/// A class containing extension methods for <see cref="ITestOutputHelperAccessor"/>. This class cannot be inherited.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static partial class ITestOutputHelperAccessorExtensions
+{
+    /// <summary>
+    /// Captures the current <see cref="ITestOutputHelper"/> from <see cref="TestContext.Current"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the implementation of <see cref="ITestOutputHelperAccessor"/>.</typeparam>
+    /// <param name="accessor">The <typeparamref name="T"/> to store the captured output helper in.</param>
+    /// <returns>
+    /// The value specified by <paramref name="accessor"/>.
+    /// </returns>
+    /// <remarks>
+    /// This method must be called from the test class constructor or the test method itself.
+    /// If this method is called from a background task or another thread, the <see cref="ITestOutputHelper"/>
+    /// associated with the test will not be captured and no log output will be observed.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="accessor"/> is <see langword="null"/>.
+    /// </exception>
+    public static T WithOutputHelperFromTestContext<T>(this T accessor)
+        where T : ITestOutputHelperAccessor
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(accessor);
+#else
+        if (accessor == null)
+        {
+            throw new ArgumentNullException(nameof(accessor));
+        }
+#endif
+
+        accessor.OutputHelper = TestContext.Current.TestOutputHelper;
+
+        return accessor;
+    }
+}

--- a/src/Logging.XUnit.v3/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Logging.XUnit.v3/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+MartinCostello.Logging.XUnit.ITestOutputHelperAccessorExtensions
+static MartinCostello.Logging.XUnit.ITestOutputHelperAccessorExtensions.WithOutputHelperFromTestContext<T>(this T accessor) -> T

--- a/src/Logging.XUnit.v3/TestContextTestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit.v3/TestContextTestOutputHelperAccessor.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Logging.XUnit;
+
+/// <summary>
+/// A class representing an implementation of <see cref="ITestOutputHelperAccessor"/> that
+/// retrieves the <see cref="ITestOutputHelper"/> from <see cref="TestContext.Current"/>. This class cannot be inherited.
+/// </summary>
+internal sealed class TestContextTestOutputHelperAccessor : ITestOutputHelperAccessor
+{
+    /// <summary>
+    /// The singleton instance of <see cref="TestContextTestOutputHelperAccessor"/>. This field is read-only.
+    /// </summary>
+    internal static readonly TestContextTestOutputHelperAccessor Instance = new();
+
+    /// <summary>
+    /// Gets or sets the current <see cref="ITestOutputHelper"/>.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// An attempt to set the value of this property is made.
+    /// </exception>
+    public ITestOutputHelper? OutputHelper
+    {
+        get => TestContext.Current?.TestOutputHelper;
+        set => throw new NotSupportedException($"Setting this property is not supported when xunit's {nameof(TestContext)} is used as the source of the current {nameof(ITestOutputHelper)}.");
+    }
+}

--- a/src/Logging.XUnit.v3/TestContextTestOutputHelperAccessor.cs
+++ b/src/Logging.XUnit.v3/TestContextTestOutputHelperAccessor.cs
@@ -22,7 +22,7 @@ internal sealed class TestContextTestOutputHelperAccessor : ITestOutputHelperAcc
     /// </exception>
     public ITestOutputHelper? OutputHelper
     {
-        get => TestContext.Current?.TestOutputHelper;
+        get => TestContext.Current.TestOutputHelper;
         set => throw new NotSupportedException($"Setting this property is not supported when xunit's {nameof(TestContext)} is used as the source of the current {nameof(ITestOutputHelper)}.");
     }
 }

--- a/src/Shared/AmbientTestOutputHelperAccessor.cs
+++ b/src/Shared/AmbientTestOutputHelperAccessor.cs
@@ -10,6 +10,11 @@ namespace MartinCostello.Logging.XUnit;
 internal sealed class AmbientTestOutputHelperAccessor : ITestOutputHelperAccessor
 {
     /// <summary>
+    /// The singleton instance of <see cref="AmbientTestOutputHelperAccessor"/>. This field is read-only.
+    /// </summary>
+    internal static readonly AmbientTestOutputHelperAccessor Instance = new();
+
+    /// <summary>
     /// A backing field for the <see cref="ITestOutputHelper"/> for the current thread.
     /// </summary>
     private static readonly AsyncLocal<ITestOutputHelper?> _current = new();

--- a/src/Shared/XUnitLoggerExtensions.ITestOutputHelper.cs
+++ b/src/Shared/XUnitLoggerExtensions.ITestOutputHelper.cs
@@ -34,7 +34,13 @@ public static partial class XUnitLoggerExtensions
         }
 #endif
 
-        return builder.AddXUnit(new AmbientTestOutputHelperAccessor(), static (_) => { });
+#if XUNIT_V3
+        var accessor = CompositeTestOutputHelperAccessor.Instance;
+#else
+        var accessor = AmbientTestOutputHelperAccessor.Instance;
+#endif
+
+        return builder.AddXUnit(accessor, static (_) => { });
     }
 
     /// <summary>

--- a/src/Shared/XUnitLoggerExtensions.ITestOutputHelper.cs
+++ b/src/Shared/XUnitLoggerExtensions.ITestOutputHelper.cs
@@ -21,7 +21,7 @@ public static partial class XUnitLoggerExtensions
     /// The instance of <see cref="ILoggingBuilder"/> specified by <paramref name="builder"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">
-    /// <paramref name="builder"/>  is <see langword="null"/>.
+    /// <paramref name="builder"/> is <see langword="null"/>.
     /// </exception>
     public static ILoggingBuilder AddXUnit(this ILoggingBuilder builder)
     {

--- a/tests/Logging.XUnit.v3.Tests/Integration/WebApplicationFactoryTests.cs
+++ b/tests/Logging.XUnit.v3.Tests/Integration/WebApplicationFactoryTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Martin Costello, 2018. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging;
+
+namespace MartinCostello.Logging.XUnit.Integration;
+
+public sealed class WebApplicationFactoryTests
+{
+    [Fact]
+    public async Task Http_Get_Many()
+    {
+        // Arrange
+        using var fixture = new WebApplicationFactoryFixture();
+        using var httpClient = fixture.CreateClient();
+
+        // Act
+        using var response = await httpClient.GetAsync("api/values", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.IsSuccessStatusCode.ShouldBeTrue();
+    }
+
+    private sealed class WebApplicationFactoryFixture : WebApplicationFactory<SampleApp.Program>
+    {
+        /// <inheritdoc />
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+            => builder.ConfigureLogging((p) => p.AddXUnit(TestContext.Current.TestOutputHelper!));
+    }
+}

--- a/tests/Shared/Integration/HttpApplicationTests.cs
+++ b/tests/Shared/Integration/HttpApplicationTests.cs
@@ -13,7 +13,9 @@ public sealed class HttpApplicationTests : IDisposable
     public HttpApplicationTests(HttpServerFixture fixture, ITestOutputHelper outputHelper)
     {
         Fixture = fixture;
+#if !XUNIT_V3
         Fixture.OutputHelper = outputHelper;
+#endif
     }
 
     private HttpServerFixture Fixture { get; }

--- a/tests/Shared/Integration/HttpApplicationTests.cs
+++ b/tests/Shared/Integration/HttpApplicationTests.cs
@@ -12,8 +12,12 @@ public sealed class HttpApplicationTests : IDisposable
 {
     public HttpApplicationTests(HttpServerFixture fixture, ITestOutputHelper outputHelper)
     {
+#if XUNIT_V3
+        Fixture = fixture.WithOutputHelperFromTestContext();
+#else
         Fixture = fixture;
         Fixture.OutputHelper = outputHelper;
+#endif
     }
 
     private HttpServerFixture Fixture { get; }
@@ -108,4 +112,22 @@ public sealed class HttpApplicationTests : IDisposable
         // Assert
         response.IsSuccessStatusCode.ShouldBeTrue();
     }
+
+#if XUNIT_V3
+    [Fact]
+    public async Task Http_Get_Many_With_OutputHelper_From_Current_Test_Method_Context()
+    {
+        // Arrange
+        using var fixture = new HttpServerFixture();
+        fixture.WithOutputHelperFromTestContext();
+
+        using var httpClient = fixture.CreateClient();
+
+        // Act
+        using var response = await httpClient.GetAsync("api/values", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.IsSuccessStatusCode.ShouldBeTrue();
+    }
+#endif
 }

--- a/tests/Shared/Integration/HttpApplicationTests.cs
+++ b/tests/Shared/Integration/HttpApplicationTests.cs
@@ -13,9 +13,7 @@ public sealed class HttpApplicationTests : IDisposable
     public HttpApplicationTests(HttpServerFixture fixture, ITestOutputHelper outputHelper)
     {
         Fixture = fixture;
-#if !XUNIT_V3
         Fixture.OutputHelper = outputHelper;
-#endif
     }
 
     private HttpServerFixture Fixture { get; }

--- a/tests/Shared/Integration/HttpServerFixture.cs
+++ b/tests/Shared/Integration/HttpServerFixture.cs
@@ -17,9 +17,5 @@ public sealed class HttpServerFixture : WebApplicationFactory<SampleApp.Program>
 
     /// <inheritdoc />
     protected override void ConfigureWebHost(IWebHostBuilder builder)
-#if XUNIT_V3
-        => builder.ConfigureLogging((p) => p.AddXUnit());
-#else
         => builder.ConfigureLogging((p) => p.AddXUnit(this));
-#endif
 }

--- a/tests/Shared/Integration/HttpServerFixture.cs
+++ b/tests/Shared/Integration/HttpServerFixture.cs
@@ -17,5 +17,9 @@ public sealed class HttpServerFixture : WebApplicationFactory<SampleApp.Program>
 
     /// <inheritdoc />
     protected override void ConfigureWebHost(IWebHostBuilder builder)
+#if XUNIT_V3
+        => builder.ConfigureLogging((p) => p.AddXUnit());
+#else
         => builder.ConfigureLogging((p) => p.AddXUnit(this));
+#endif
 }

--- a/tests/Shared/XUnitLoggerExtensionsTests.cs
+++ b/tests/Shared/XUnitLoggerExtensionsTests.cs
@@ -147,7 +147,12 @@ public static class XUnitLoggerExtensionsTests
         // Assert
         var serviceProvider = services.BuildServiceProvider();
         serviceProvider.GetService<ILoggerProvider>().ShouldBeOfType<XUnitLoggerProvider>();
+
+#if XUNIT_V3
+        serviceProvider.GetService<ITestOutputHelperAccessor>().ShouldBeOfType<CompositeTestOutputHelperAccessor>();
+#else
         serviceProvider.GetService<ITestOutputHelperAccessor>().ShouldBeOfType<AmbientTestOutputHelperAccessor>();
+#endif
     }
 
     [Fact]


### PR DESCRIPTION
Initial skeleton of implementing #866.

It doesn't actually work at the moment because the context is backed by an `AsyncLocal<T>`, so any background threads running in the context of a test don't observe the actual current `ITestOutputHelper`, so the original reason `ITestOutputHelperAccessor` exists still applies.
