### PR TITLE
Add TimeProvider

### DIFF
--- a/src/Logging.XUnit.v3/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Logging.XUnit.v3/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Logging.XUnit.v3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Logging.XUnit.v3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+MartinCostello.Logging.XUnit.XUnitLoggerOptions.TimeProvider.get -> System.TimeProvider!
+MartinCostello.Logging.XUnit.XUnitLoggerOptions.TimeProvider.set -> void

--- a/src/Logging.XUnit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Logging.XUnit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Logging.XUnit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Logging.XUnit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+MartinCostello.Logging.XUnit.XUnitLoggerOptions.TimeProvider.get -> System.TimeProvider!
+MartinCostello.Logging.XUnit.XUnitLoggerOptions.TimeProvider.set -> void

--- a/src/Shared/XUnitLogger.cs
+++ b/src/Shared/XUnitLogger.cs
@@ -39,6 +39,15 @@ public partial class XUnitLogger : ILogger
     /// </summary>
     private readonly string _timestampFormat;
 
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// The time provider used in log messages.
+    /// </summary>
+    private readonly TimeProvider _timeProvider;
+
+#endif
+
     /// <summary>
     /// Gets or sets the filter to use.
     /// </summary>
@@ -57,6 +66,12 @@ public partial class XUnitLogger : ILogger
         _messageSinkMessageFactory = options?.MessageSinkMessageFactory ?? (static (message) => new DiagnosticMessage(message));
         _timestampFormat = options?.TimestampFormat ?? "u";
         IncludeScopes = options?.IncludeScopes ?? false;
+#if NET8_0_OR_GREATER
+        _timeProvider = options?.TimeProvider ?? TimeProvider.System;
+        Clock = () => _timeProvider.GetLocalNow();
+#else
+        Clock = static () => DateTimeOffset.Now;
+#endif
     }
 
     /// <summary>
@@ -84,7 +99,7 @@ public partial class XUnitLogger : ILogger
     /// <summary>
     /// Gets or sets a delegate representing the system clock.
     /// </summary>
-    internal Func<DateTimeOffset> Clock { get; set; } = static () => DateTimeOffset.Now;
+    internal Func<DateTimeOffset> Clock { get; set; }
 
     /// <inheritdoc />
     public IDisposable? BeginScope<TState>(TState state)

--- a/src/Shared/XUnitLoggerOptions.cs
+++ b/src/Shared/XUnitLoggerOptions.cs
@@ -38,4 +38,13 @@ public class XUnitLoggerOptions
     /// </summary>
     [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
     public string? TimestampFormat { get; set; }
+
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// Gets or sets the time provider used in log messages. Defaults to <see cref="TimeProvider.System"/>.
+    /// </summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+#endif
 }

--- a/tests/Shared/XUnitLoggerTests.cs
+++ b/tests/Shared/XUnitLoggerTests.cs
@@ -659,6 +659,41 @@ public static class XUnitLoggerTests
         outputHelper.Received(1).WriteLine(expected);
     }
 
+#if NET8_0_OR_GREATER
+
+    [Fact]
+    public static void XUnitLogger_Log_Logs_Message_With_TimeProvider()
+    {
+        // Arrange
+        var outputHelper = Substitute.For<ITestOutputHelper>();
+        string name = "MyName";
+
+        var timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.LocalTimeZone.Returns(TimeZoneInfo.FindSystemTimeZoneById("Europe/London"));
+        timeProvider.GetUtcNow().Returns(new DateTimeOffset(2019, 05, 12, 13, 47, 41, 123, 456, TimeSpan.Zero));
+
+        var options = new XUnitLoggerOptions()
+        {
+            Filter = FilterTrue,
+            TimeProvider = timeProvider,
+        };
+
+        var logger = new XUnitLogger(name, outputHelper, options);
+
+        string expected = string.Join(
+            Environment.NewLine,
+            "[2019-05-12 13:47:41Z] info: MyName[85]",
+            "      Message|True|False");
+
+        // Act
+        logger.Log(LogLevel.Information, new EventId(85), "Martin", null, Formatter);
+
+        // Assert
+        outputHelper.Received(1).WriteLine(expected);
+    }
+
+#endif
+
     private static DateTimeOffset StaticClock() => new(2018, 08, 19, 17, 12, 16, TimeSpan.FromHours(1));
 
     private static DiagnosticMessage DiagnosticMessageFactory(string message) => new(message);


### PR DESCRIPTION
Implements support for the [`TimeProvider`](https://learn.microsoft.com/dotnet/standard/datetime/timeprovider-overview) (closes https://github.com/martincostello/xunit-logging/issues/911).