### PR TITLE
Update renovate comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,14 @@ jobs:
       matrix:
         include:
           - os-name: macos
-            # renovate: datasource=github-runners depName=macos depType=github-runner
-            runner: macos-26
+            # renovate: datasource=github-runners depType=github-runner
+            runner: macos-15
           - os-name: linux
-            # renovate: datasource=github-runners depName=ubuntu depType=github-runner
-            runner: ubuntu-24.04
+            # renovate: datasource=github-runners depType=github-runner
+            runner: ubuntu-22.04
           - os-name: windows
-            # renovate: datasource=github-runners depName=windows depType=github-runner
-            runner: windows-2025
+            # renovate: datasource=github-runners depType=github-runner
+            runner: windows-2022
 
     steps:
 


### PR DESCRIPTION
- Remove `depName` from comments.
- Downgrade versions to test renovate upgrades.
