### PR TITLE
Include log state when scopes are enabled

### DIFF
--- a/src/Shared/XUnitLogger.cs
+++ b/src/Shared/XUnitLogger.cs
@@ -135,6 +135,11 @@ public partial class XUnitLogger : ILogger
 
         if (!string.IsNullOrEmpty(message) || exception != null)
         {
+            if (IncludeScopes && state is not null)
+            {
+                message = AddStateToMessage(message, state);
+            }
+
             WriteMessage(logLevel, eventId.Id, message, exception);
         }
     }
@@ -273,7 +278,7 @@ public partial class XUnitLogger : ILogger
         while (stack.Count > 0)
         {
             var elem = stack.Pop();
-            foreach (var property in StringifyScope(elem))
+            foreach (var property in StringifyState(elem.State))
             {
                 builder.Append(MessagePadding)
                        .Append(DepthPadding(depth))
@@ -287,20 +292,54 @@ public partial class XUnitLogger : ILogger
     }
 
     /// <summary>
-    /// Returns one or more stringified properties from the log scope.
+    /// Adds one or more stringified properties from the log state to the message.
     /// </summary>
-    /// <param name="scope">The <see cref="XUnitLogScope"/> to stringify.</param>
-    /// <returns>An enumeration of scope properties from the current scope.</returns>
-    private static IEnumerable<string?> StringifyScope(XUnitLogScope scope)
+    /// <param name="message">The formatted log message.</param>
+    /// <param name="state">The log state to add.</param>
+    /// <returns>The formatted message including the log state.</returns>
+    private static string? AddStateToMessage(string? message, object state)
     {
-        if (scope.State is IEnumerable<KeyValuePair<string, object>> pairs)
+        var builder = new StringBuilder();
+
+        foreach (var property in StringifyState(state))
+        {
+            if (builder.Length > 0)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append("=> ");
+            builder.Append(property);
+        }
+
+        if (!string.IsNullOrEmpty(message))
+        {
+            if (builder.Length > 0)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(message);
+        }
+
+        return builder.Length > 0 ? builder.ToString() : message;
+    }
+
+    /// <summary>
+    /// Returns one or more stringified properties from the specified state.
+    /// </summary>
+    /// <param name="state">The state to stringify.</param>
+    /// <returns>An enumeration of properties from the specified state.</returns>
+    private static IEnumerable<string?> StringifyState(object state)
+    {
+        if (state is IEnumerable<KeyValuePair<string, object>> pairs)
         {
             foreach (var pair in pairs)
             {
                 yield return $"{pair.Key}: {pair.Value}";
             }
         }
-        else if (scope.State is IEnumerable<string> entries)
+        else if (state is IEnumerable<string> entries)
         {
             foreach (var entry in entries)
             {
@@ -309,7 +348,7 @@ public partial class XUnitLogger : ILogger
         }
         else
         {
-            yield return scope.ToString();
+            yield return state.ToString();
         }
     }
 }

--- a/src/Shared/XUnitLogger.cs
+++ b/src/Shared/XUnitLogger.cs
@@ -278,7 +278,7 @@ public partial class XUnitLogger : ILogger
         while (stack.Count > 0)
         {
             var elem = stack.Pop();
-            foreach (var property in StringifyState(elem.State))
+            foreach (var property in StringifyScope(elem))
             {
                 builder.Append(MessagePadding)
                        .Append(DepthPadding(depth))
@@ -288,6 +288,33 @@ public partial class XUnitLogger : ILogger
             }
 
             depth++;
+        }
+    }
+
+    /// <summary>
+    /// Returns one or more stringified properties from the log scope.
+    /// </summary>
+    /// <param name="scope">The <see cref="XUnitLogScope"/> to stringify.</param>
+    /// <returns>An enumeration of scope properties from the current scope.</returns>
+    private static IEnumerable<string?> StringifyScope(XUnitLogScope scope)
+    {
+        if (scope.State is IEnumerable<KeyValuePair<string, object>> pairs)
+        {
+            foreach (var pair in pairs)
+            {
+                yield return $"{pair.Key}: {pair.Value}";
+            }
+        }
+        else if (scope.State is IEnumerable<string> entries)
+        {
+            foreach (var entry in entries)
+            {
+                yield return entry;
+            }
+        }
+        else
+        {
+            yield return scope.ToString();
         }
     }
 

--- a/tests/Shared/XUnitLoggerTests.cs
+++ b/tests/Shared/XUnitLoggerTests.cs
@@ -446,6 +446,53 @@ public static class XUnitLoggerTests
     }
 
     [Fact]
+    public static void XUnitLogger_Log_Logs_State_If_Scopes_Included()
+    {
+        // Arrange
+        var outputHelper = Substitute.For<ITestOutputHelper>();
+        string name = "MyName";
+
+        var options = new XUnitLoggerOptions()
+        {
+            Filter = FilterTrue,
+            IncludeScopes = true,
+        };
+
+        var logger = new XUnitLogger(name, outputHelper, options)
+        {
+            Clock = StaticClock,
+        };
+
+        string expected = string.Join(
+            Environment.NewLine,
+            "[2018-08-19 16:12:16Z] info: MyName[0]",
+            "      => ScopeKey: ScopeValue",
+            "      => StateKey: StateValue",
+            "      => {OriginalFormat}: Message from {StateKey}",
+            "      Message|True|False");
+
+        using (logger.BeginScope(new[]
+        {
+            new KeyValuePair<string, object>("ScopeKey", "ScopeValue"),
+        }))
+        {
+            logger.Log(
+                LogLevel.Information,
+                0,
+                new[]
+                {
+                    new KeyValuePair<string, object>("StateKey", "StateValue"),
+                    new KeyValuePair<string, object>("{OriginalFormat}", "Message from {StateKey}"),
+                },
+                null,
+                Formatter);
+        }
+
+        // Assert
+        outputHelper.Received(1).WriteLine(expected);
+    }
+
+    [Fact]
     public static void XUnitLogger_Log_Logs_Message_If_Scopes_Included_And_There_Are_Scopes()
     {
         // Arrange

--- a/tests/Shared/XUnitLoggerTests.cs
+++ b/tests/Shared/XUnitLoggerTests.cs
@@ -493,6 +493,39 @@ public static class XUnitLoggerTests
     }
 
     [Fact]
+    public static void XUnitLogger_Log_Logs_Non_Structured_State_If_Scopes_Included()
+    {
+        // Arrange
+        var outputHelper = Substitute.For<ITestOutputHelper>();
+        string name = "MyName";
+
+        var options = new XUnitLoggerOptions()
+        {
+            Filter = FilterTrue,
+            IncludeScopes = true,
+        };
+
+        var logger = new XUnitLogger(name, outputHelper, options)
+        {
+            Clock = StaticClock,
+        };
+
+        var exception = new InvalidOperationException("Invalid");
+
+        string expected = string.Join(
+            Environment.NewLine,
+            "[2018-08-19 16:12:16Z] info: MyName[0]",
+            "      => state",
+            "System.InvalidOperationException: Invalid");
+
+        // Act
+        logger.Log(LogLevel.Information, 0, "state", exception, FormatterEmpty);
+
+        // Assert
+        outputHelper.Received(1).WriteLine(expected);
+    }
+
+    [Fact]
     public static void XUnitLogger_Log_Logs_Message_If_Scopes_Included_And_There_Are_Scopes()
     {
         // Arrange


### PR DESCRIPTION
Fixes #982

This includes the state passed to `Log<TState>()` in the formatted output when scopes are enabled.

Structured state uses the existing scope formatting rules and is written after ambient scopes and before the formatted message. The public `WriteMessage()` API and behavior when scopes are disabled remain unchanged.

## Tests

- `dotnet test --configuration Release`
  - xUnit v2: 73 passed
  - xUnit v3: 73 passed
- Package validation passed for both NuGet packages.
- Line coverage: 98.96%
- Branch coverage: 95.49%
- Method coverage: 98.73%